### PR TITLE
Add --set-as-main flag support to repository bumper

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -108,7 +108,7 @@ jobs:
           set_as_main=${{ inputs.set_as_main }}
           script_params=("${{ steps.vars.outputs.version }}" "${{ steps.vars.outputs.stage }}")
           if [[ "$set_as_main" == "true" ]]; then
-            script_params=("--set-as-main" "${script_params[@]}")
+            script_params+=("--set-as-main")
           fi
           bash "${{ env.BUMP_SCRIPT_PATH }}" "${script_params[@]}"
 

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -22,6 +22,11 @@ on:
         description: 'Optional identifier for the run'
         required: false
         type: string
+      set_as_main:
+        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   bump:
@@ -100,9 +105,25 @@ jobs:
       - name: Make version bump changes
         run: |
           echo "Running bump script"
-          bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.version }} ${{ steps.vars.outputs.stage }}
+          set_as_main=${{ inputs.set_as_main }}
+          script_params=("${{ steps.vars.outputs.version }}" "${{ steps.vars.outputs.stage }}")
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params=("--set-as-main" "${script_params[@]}")
+          fi
+          bash "${{ env.BUMP_SCRIPT_PATH }}" "${script_params[@]}"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "No changes produced by bump script. Exiting without creating PR."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Commit and push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           git add .
           git commit -m "feat: bump ${{ github.ref_name }}"
@@ -110,6 +131,7 @@ jobs:
 
       - name: Create pull request
         id: create_pr
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -122,6 +144,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --squash --admin
@@ -130,6 +153,6 @@ jobs:
         run: |
           echo "Bump complete."
           echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          echo "PR: ${{ steps.create_pr.outputs.pull_request_url || 'N/A (no changes)' }}"
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ yarn-error.log
 
 artifacts/
 bin/
+
+# log files
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Initialize repository. [(#2)](https://github.com/wazuh/wazuh-indexer-notifications/issues/2)
 - Implement wazuh-indexer-common-utils usage [(#17)](https://github.com/wazuh/wazuh-indexer-notifications/pull/17)
 - Add active response channel [(#7)](https://github.com/wazuh/wazuh-indexer-notifications/pull/7)
+- Add `--set-as-main` flag support to repository bumper [(#23)](https://github.com/wazuh/wazuh-indexer-notifications/pull/23)
 
 ### Dependencies
 -

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -8,6 +8,7 @@
 # It takes three arguments:
 # 1. The new version to set (e.g., 4.5.0)
 # 2. The new stage to set (alpha, beta, rc, stable)
+# 3. --set-as-main (optional): bump version values only, keep branch references pointing to main
 #
 
 set -euo pipefail
@@ -145,7 +146,6 @@ function main() {
     local version="$1"
     local stage="$2"
     local set_as_main=""
-    local skip_urls="no"
 
     shift 2
     while [[ $# -gt 0 ]]; do
@@ -161,32 +161,14 @@ function main() {
         esac
     done
 
-    if [[ -n "$set_as_main" ]]; then
-        log "Main branch mode enabled: version values will be updated but branch references will remain pointing to main."
-        skip_urls="yes"
-    else
-        log "Freeze mode: version values and branch references will both be updated."
-        skip_urls="no"
-    fi
-
     init_logging
+
     log "Starting update for VERSION.json with version=$version, stage=$stage"
 
     navigate_to_project_root
     check_jq_installed
     validate_inputs "$version" "$stage"
     update_version_file "$version" "$stage"
-
-    # Replace 'main' branch references with the version string (freeze mode only)
-    # NOTE: This repository currently has no branch/URL reference replacements.
-    # If such references are added in the future, place the sed commands here.
-    #
-    # Example:
-    #   sed -Ei "s/(some_field:\s*)main/\1${version}/g" path/to/file
-    if [[ "$skip_urls" != "yes" ]]; then
-        log "No branch/URL reference replacements defined for this repository. Skipping."
-    fi
-
     log "Update complete."
 }
 

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -16,54 +16,13 @@ set -euo pipefail
 # Print usage instructions
 # ====
 function usage() {
-    echo "Usage: $0 [--set-as-main] <version> <stage>"
-    echo "  --set-as-main  Enable main branch mode: bump version values only, keep branch references pointing to main"
+    echo "Usage: $0 <version> <stage> [--set-as-main]"
     echo "  version:       The new version to set in VERSION.json (e.g., 4.5.0)"
     echo "  stage:         The new stage to set in VERSION.json (alpha, beta, rc, stable)"
+    echo "  --set-as-main  Enable main branch mode: bump version values only, keep branch references pointing to main"
     exit 1
 }
 
-# ====
-# Parse arguments
-# Globals:
-#   version
-#   stage
-#   set_as_main
-#   skip_urls
-# ====
-function parse_args() {
-    set_as_main=""
-
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --set-as-main)
-                set_as_main="yes"
-                shift 1
-                ;;
-            -*)
-                log "Error: Unknown option '$1'."
-                usage
-                ;;
-            *)
-                break
-                ;;
-        esac
-    done
-
-    if [[ $# -ne 2 ]]; then
-        log "Error: Invalid number of positional arguments. Expected 2, got $#."
-        usage
-    fi
-
-    version="$1"
-    stage="$2"
-
-    if [[ -n "$set_as_main" ]]; then
-        skip_urls="yes"
-    else
-        skip_urls="no"
-    fi
-}
 
 # ====
 # Initialize logging
@@ -173,15 +132,60 @@ function update_version_file() {
 # Main logic
 # ====
 function main() {
-    parse_args "$@"
+    if [[ $# -lt 2 ]]; then
+        log "Error: Invalid number of arguments. Expected at least 2, got $#."
+        usage
+    fi
+
+    if [[ $# -gt 3 ]]; then
+        log "Error: Too many arguments. Expected at most 3, got $#."
+        usage
+    fi
+
+    local version="$1"
+    local stage="$2"
+    local set_as_main=""
+    local skip_urls="no"
+
+    shift 2
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --set-as-main)
+                set_as_main="yes"
+                shift 1
+                ;;
+            *)
+                log "Error: Unknown argument '$1'."
+                usage
+                ;;
+        esac
+    done
+
+    if [[ -n "$set_as_main" ]]; then
+        log "Main branch mode enabled: version values will be updated but branch references will remain pointing to main."
+        skip_urls="yes"
+    else
+        log "Freeze mode: version values and branch references will both be updated."
+        skip_urls="no"
+    fi
 
     init_logging
-    log "Starting update for VERSION.json with version=$version, stage=$stage, set_as_main=${set_as_main:-no}"
+    log "Starting update for VERSION.json with version=$version, stage=$stage"
 
     navigate_to_project_root
     check_jq_installed
     validate_inputs "$version" "$stage"
     update_version_file "$version" "$stage"
+
+    # Replace 'main' branch references with the version string (freeze mode only)
+    # NOTE: This repository currently has no branch/URL reference replacements.
+    # If such references are added in the future, place the sed commands here.
+    #
+    # Example:
+    #   sed -Ei "s/(some_field:\s*)main/\1${version}/g" path/to/file
+    if [[ "$skip_urls" != "yes" ]]; then
+        log "No branch/URL reference replacements defined for this repository. Skipping."
+    fi
 
     log "Update complete."
 }

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -16,10 +16,53 @@ set -euo pipefail
 # Print usage instructions
 # ====
 function usage() {
-    echo "Usage: $0 <version> <stage>"
-    echo "  version:  The new version to set in VERSION.json (e.g., 4.5.0)"
-    echo "  stage:    The new stage to set in VERSION.json (alpha, beta, rc, stable)"
+    echo "Usage: $0 [--set-as-main] <version> <stage>"
+    echo "  --set-as-main  Enable main branch mode: bump version values only, keep branch references pointing to main"
+    echo "  version:       The new version to set in VERSION.json (e.g., 4.5.0)"
+    echo "  stage:         The new stage to set in VERSION.json (alpha, beta, rc, stable)"
     exit 1
+}
+
+# ====
+# Parse arguments
+# Globals:
+#   version
+#   stage
+#   set_as_main
+#   skip_urls
+# ====
+function parse_args() {
+    set_as_main=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --set-as-main)
+                set_as_main="yes"
+                shift 1
+                ;;
+            -*)
+                log "Error: Unknown option '$1'."
+                usage
+                ;;
+            *)
+                break
+                ;;
+        esac
+    done
+
+    if [[ $# -ne 2 ]]; then
+        log "Error: Invalid number of positional arguments. Expected 2, got $#."
+        usage
+    fi
+
+    version="$1"
+    stage="$2"
+
+    if [[ -n "$set_as_main" ]]; then
+        skip_urls="yes"
+    else
+        skip_urls="no"
+    fi
 }
 
 # ====
@@ -130,16 +173,10 @@ function update_version_file() {
 # Main logic
 # ====
 function main() {
-    if [ "$#" -ne 2 ]; then
-        log "Error: Invalid number of arguments. Expected 2, got $#."
-        usage
-    fi
-
-    local version="$1"
-    local stage="$2"
+    parse_args "$@"
 
     init_logging
-    log "Starting update for VERSION.json with version=$version, stage=$stage"
+    log "Starting update for VERSION.json with version=$version, stage=$stage, set_as_main=${set_as_main:-no}"
 
     navigate_to_project_root
     check_jq_installed


### PR DESCRIPTION
### Description

This PR adds support for the `--set-as-main` flag in the repository bumper script and its associated workflow, as part of the two-step version bump flow from `main`.

### Changes

**`tools/repository_bumper.sh`**
- Added `--set-as-main` optional flag parsed after positional args via `shift 2`
- Main branch mode (`--set-as-main`): updates version values only, branch references stay pointing to `main`
- Freeze mode (no flag): updates version values and branch references
- Added input validation: too few, too many, and unknown arguments
- Added placeholder block for future branch reference `sed` replacements

**`.github/workflows/5_bumper_repository.yml`**
- Added `set_as_main` boolean input to `workflow_dispatch`
- Appends `--set-as-main` to the script call when input is `true`
- Added no-op check: exits cleanly without creating a PR if no files changed

### Related Issues

Resolves #22

### Validation

Validated locally by running the bumper script.

#### Scenario A: main branch mode (`--set-as-main`)

```bash
bash tools/repository_bumper.sh 5.1.0 beta0 --set-as-main
```

```
[2026-03-30 12:39:51] Main branch mode enabled: version values will be updated but branch references will remain pointing to main.
[2026-03-30 12:39:51] Starting update for VERSION.json with version=5.1.0, stage=beta0
[2026-03-30 12:39:51] Updated VERSION.json with version=5.1.0 and stage=beta0
[2026-03-30 12:39:51] Update complete.
```

#### Scenario B: freeze mode (no flag)

```bash
bash tools/repository_bumper.sh 5.1.0 beta0
```

```
[2026-03-30 12:40:22] Freeze mode: version values and branch references will both be updated.
[2026-03-30 12:40:22] Starting update for VERSION.json with version=5.1.0, stage=beta0
[2026-03-30 12:40:22] Updated VERSION.json with version=5.1.0 and stage=beta0
[2026-03-30 12:40:22] No branch/URL reference replacements defined for this repository. Skipping.
[2026-03-30 12:40:22] Update complete.
```

#### Scenario C: unknown argument

```bash
bash tools/repository_bumper.sh 5.0.0 alpha0 potatoe
```

```
[2026-03-30 12:24:05] Error: Unknown argument 'potatoe'.
Usage: tools/repository_bumper.sh <version> <stage> [--set-as-main]
```

#### Scenario D: too few arguments

```bash
bash tools/repository_bumper.sh 5.0.0
```

```
[2026-03-30 12:24:09] Error: Invalid number of arguments. Expected at least 2, got 1.
Usage: tools/repository_bumper.sh <version> <stage> [--set-as-main]
```

#### Scenario E: too many arguments

```bash
bash tools/repository_bumper.sh 5.0.0 alpha0 --set-as-main extra
```

```
[2026-03-30 12:37:41] Error: Too many arguments. Expected at most 3, got 4.
Usage: tools/repository_bumper.sh <version> <stage> [--set-as-main]
```