### PR TITLE
Make extra_args nullable and convert empty strings to null

### DIFF
--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ActiveResponseDestination.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ActiveResponseDestination.kt
@@ -13,12 +13,10 @@ class ActiveResponseDestination(
     val type: String,
     val stateful_timeout: Int? = null,
     val executable: String,
-    extra_args: String? = null,
+    val extra_args: String? = null,
     val location: String,
     val agent_id: String? = null
 ) : BaseDestination(DestinationType.ACTIVE_RESPONSE) {
-
-    val extra_args: String? = extra_args?.ifBlank { null }
 
     init {
 

--- a/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ActiveResponseDestination.kt
+++ b/notifications/core-spi/src/main/kotlin/org/opensearch/notifications/spi/model/destination/ActiveResponseDestination.kt
@@ -13,10 +13,12 @@ class ActiveResponseDestination(
     val type: String,
     val stateful_timeout: Int? = null,
     val executable: String,
-    val extra_args: String,
+    extra_args: String? = null,
     val location: String,
     val agent_id: String? = null
 ) : BaseDestination(DestinationType.ACTIVE_RESPONSE) {
+
+    val extra_args: String? = extra_args?.ifBlank { null }
 
     init {
 

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -308,7 +308,7 @@ object SendMessageActionHelper {
                 "type" to activeResponse.type,
                 "stateful_timeout" to activeResponse.statefulTimeout,
                 "executable" to activeResponse.executable,
-                "extra_arguments" to activeResponse.args,
+                "extra_arguments" to activeResponse.args?.ifBlank { null },
                 "location" to activeResponse.location,
                 "agent_id" to activeResponse.agentId
             )

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -308,7 +308,7 @@ object SendMessageActionHelper {
                 "type" to activeResponse.type,
                 "stateful_timeout" to activeResponse.statefulTimeout,
                 "executable" to activeResponse.executable,
-                "extra_arguments" to activeResponse.args?.ifBlank { null },
+                "extra_arguments" to activeResponse.args,
                 "location" to activeResponse.location,
                 "agent_id" to activeResponse.agentId
             )


### PR DESCRIPTION
## Description

Makes the `extra_args` field in `ActiveResponseDestination` nullable (`String?`). If an empty or blank string is provided, it is automatically converted to `null`.

### Related Issues

Closes https://github.com/wazuh/wazuh-dashboard-notifications/issues/19


### Screenshots

<img width="1724" height="1344" alt="image" src="https://github.com/user-attachments/assets/98086625-5119-4c5d-9edc-a5cddd4b5023" />
<img width="1779" height="1346" alt="image" src="https://github.com/user-attachments/assets/6df0ec70-dcd5-4c12-b6a5-ad3ef0c0ea12" />

## How to test

Try creating Active Responses using the empty and data placeholders; when the alert is generated, it should be null if it is empty and contain the data if it had any.