### PR TITLE
Publish Zip artifacts to Maven Local

### DIFF
--- a/.github/workflows/5_builderpackage_notifications.yml
+++ b/.github/workflows/5_builderpackage_notifications.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Build with Gradle
         run: |
           cd notifications
-          ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Dbuild.revision=${{ inputs.revision }}"
+          ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=${{ inputs.revision }}"
 
       - name: Create Artifact Path
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Build with Gradle
         run: |
           cd notifications
-          ./gradlew build -x test "-Dversion=${{ needs.get-version.outputs.version }}" "-Dbuild.revision=0"
+          ./gradlew build -x test "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=0"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         wazuh_version = System.getProperty("version", "5.0.0")
-        revision = System.getProperty("build.revision", "0")
+        revision = System.getProperty("revision", "0")
         
         // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
@@ -74,7 +74,7 @@ allprojects {
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     }
-    group = "org.opensearch"
+    group = "com.wazuh"
 
     plugins.withId('java') {
         java {

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -45,7 +45,6 @@ publishing {
             pom {
                 name = "wazuh-indexer-notifications-core"
                 description = "Wazuh Indexer Notifications Core Plugin"
-                groupId = "org.opensearch.plugin"
                 licenses {
                     license {
                         name = "The Apache License, Version 2.0"
@@ -192,12 +191,18 @@ configurations {
 
 // This is afterEvaluate because the bundlePlugin ZIP task is updated afterEvaluate and changes the ZIP name to match the plugin name
 afterEvaluate {
+    if (tasks.findByName('publishNebulaPublicationToMavenLocal') && tasks.findByName('generatePomFileForPluginZipPublication')) {
+        tasks.named('publishNebulaPublicationToMavenLocal').configure {
+            dependsOn tasks.named('generatePomFileForPluginZipPublication')
+        }
+    }
+
     ospackage {
         packageName = "${name}"
         release = isSnapshot ? "0.1" : '1'
         version = "${project.version}" - "-SNAPSHOT"
 
-        into '/usr/share/opensearch/plugins'
+        into '/usr/share/wazuh-indexer/plugins'
         from(zipTree(bundlePlugin.archiveFile)) {
             into opensearchplugin.name
         }

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -55,7 +55,7 @@ publishing {
             pom {
                 name = "wazuh-indexer-notifications"
                 description = "Wazuh Indexer Notifications Plugin"
-                groupId = "org.opensearch.plugin"
+                groupId = "com.wazuh"
                 licenses {
                     license {
                         name = "The Apache License, Version 2.0"
@@ -181,7 +181,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "${group}:opensearch:${opensearch_version}"
+    compileOnly "org.opensearch:opensearch:${opensearch_version}"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3") {
@@ -267,6 +267,12 @@ es_tmp_dir.mkdirs()
 // Will need to do a deep dive to find out exactly what task adds the sample-extension-plugin and add notification-core there but a temporary hack is to
 // reorder the plugins list after evaluation but prior to task execution when the plugins are installed.
 afterEvaluate {
+    if (tasks.findByName('publishNebulaPublicationToMavenLocal') && tasks.findByName('generatePomFileForPluginZipPublication')) {
+        tasks.named('publishNebulaPublicationToMavenLocal').configure {
+            dependsOn tasks.named('generatePomFileForPluginZipPublication')
+        }
+    }
+
     testClusters.integTest.nodes.each { node ->
         def plugins = node.plugins
         def firstPlugin = plugins.get(0)

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -52,7 +52,6 @@ opensearchplugin {
 publishing {
     publications {
         pluginZip(MavenPublication) { publication ->
-            artifactId = "wazuh-indexer-notifications"
             pom {
                 name = "wazuh-indexer-notifications"
                 description = "Wazuh Indexer Notifications Plugin"

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -52,6 +52,7 @@ opensearchplugin {
 publishing {
     publications {
         pluginZip(MavenPublication) { publication ->
+            artifactId = "wazuh-indexer-notifications"
             pom {
                 name = "wazuh-indexer-notifications"
                 description = "Wazuh Indexer Notifications Plugin"
@@ -271,6 +272,11 @@ afterEvaluate {
         tasks.named('publishNebulaPublicationToMavenLocal').configure {
             dependsOn tasks.named('generatePomFileForPluginZipPublication')
         }
+    }
+
+    publishing.publications.named("pluginZip", MavenPublication).configure {
+        groupId = "com.wazuh"
+        artifactId = "wazuh-indexer-notifications"
     }
 
     testClusters.integTest.nodes.each { node ->
@@ -608,7 +614,7 @@ afterEvaluate {
         release = isSnapshot ? "0.1" : '1'
         version = "${project.version}" - "-SNAPSHOT"
 
-        into '/usr/share/opensearch/plugins'
+        into '/usr/share/wazuh-indexer/plugins'
         from(zipTree(bundlePlugin.archiveFile)) {
             into opensearchplugin.name
         }

--- a/notifications/settings.gradle
+++ b/notifications/settings.gradle
@@ -10,4 +10,3 @@ include ":core-spi"
 
 project(":core").name = rootProject.name + "-core"
 project(":core-spi").name = rootProject.name + "-core" + "-spi"
-startParameter.excludedTaskNames += ["publishPluginZipPublicationToMavenLocal"]

--- a/notifications/settings.gradle
+++ b/notifications/settings.gradle
@@ -10,4 +10,3 @@ include ":core-spi"
 
 project(":core").name = rootProject.name + "-core"
 project(":core-spi").name = rootProject.name + "-core" + "-spi"
-project(":notifications").name = rootProject.name + "-notifications"

--- a/notifications/settings.gradle
+++ b/notifications/settings.gradle
@@ -10,3 +10,4 @@ include ":core-spi"
 
 project(":core").name = rootProject.name + "-core"
 project(":core-spi").name = rootProject.name + "-core" + "-spi"
+project(":notifications").name = rootProject.name + "-notifications"


### PR DESCRIPTION
### Description

Publishes Zip artifacts to Maven Local under the `com.wazuh` group.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1439
