### PR TITLE
Fix circular dependency

### DIFF
--- a/notifications/build.gradle
+++ b/notifications/build.gradle
@@ -129,12 +129,6 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     jvmArgs "--add-opens=java.base/java.lang=ALL-UNNAMED"
 }
 
-project(':wazuh-indexer-notifications-core') {
-    tasks.matching { it.name == 'generatePomFileForPluginZipPublication' }.configureEach {
-        mustRunAfter 'publishNebulaPublicationToMavenLocal'
-    }
-}
-
 detekt {
     config = files("detekt.yml")
     buildUponDefaultConfig = true


### PR DESCRIPTION
### Description
This PR fixes an error that was causing the publication of notifications plugin to fail

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1043

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
