### PR TITLE
Implement batch Active Response indexing using BulkProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement wazuh-indexer-common-utils usage [(#17)](https://github.com/wazuh/wazuh-indexer-notifications/pull/17)
 - Add active response channel [(#7)](https://github.com/wazuh/wazuh-indexer-notifications/pull/7)
 - Add `--set-as-main` flag support to repository bumper [(#23)](https://github.com/wazuh/wazuh-indexer-notifications/pull/23)
+- Implement batch Active Response indexing using BulkProcessor [(#67)](https://github.com/wazuh/wazuh-indexer-notifications/pull/67)
 
 ### Dependencies
 -

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -223,6 +223,9 @@ class NotificationPlugin : ActionPlugin, ClusterPlugin, Plugin(), NotificationCo
     override fun close() {
         if (::activeResponseBulkIndexer.isInitialized) {
             activeResponseBulkIndexer.close()
+        }
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -38,6 +38,7 @@ import org.opensearch.notifications.resthandler.NotificationConfigRestHandler
 import org.opensearch.notifications.resthandler.NotificationFeaturesRestHandler
 import org.opensearch.notifications.resthandler.SendTestMessageRestHandler
 import org.opensearch.notifications.security.UserAccessManager
+import org.opensearch.notifications.send.ActiveResponseBulkIndexer
 import org.opensearch.notifications.send.SendMessageActionHelper
 import org.opensearch.notifications.settings.PluginSettings
 import org.opensearch.notifications.settings.PluginSettings.MULTI_TENANCY_ENABLED
@@ -73,6 +74,7 @@ import java.util.function.Supplier
 class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, SystemIndexPlugin {
 
     lateinit var clusterService: ClusterService // initialized in createComponents()
+    private lateinit var activeResponseBulkIndexer: ActiveResponseBulkIndexer
 
     internal companion object {
         private val log by logger(NotificationPlugin::class.java)
@@ -137,7 +139,12 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
         PluginSettings.addSettingsUpdateConsumer(clusterService)
         NotificationConfigIndex.initialize(sdkClient, client, clusterService)
         ConfigIndexingActions.initialize(NotificationConfigIndex, UserAccessManager)
-        SendMessageActionHelper.initialize(NotificationConfigIndex, UserAccessManager, client)
+        activeResponseBulkIndexer = ActiveResponseBulkIndexer(
+            client,
+            PluginSettings.activeResponseBulkFlushIntervalMs,
+            PluginSettings.activeResponseBulkMaxActions
+        )
+        SendMessageActionHelper.initialize(NotificationConfigIndex, UserAccessManager, client, activeResponseBulkIndexer)
         return listOf(sdkClient)
     }
 
@@ -208,5 +215,11 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
     override fun setNotificationCore(core: NotificationCore) {
         log.debug("$LOG_PREFIX:setNotificationCore")
         CoreProvider.initialize(core)
+    }
+
+    override fun close() {
+        if (::activeResponseBulkIndexer.isInitialized) {
+            activeResponseBulkIndexer.close()
+        }
     }
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/metrics/Metrics.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/metrics/Metrics.kt
@@ -216,6 +216,10 @@ enum class Metrics(val metricName: String, val counter: Counter<*>) {
     NOTIFICATIONS_MESSAGE_DESTINATION_ACTIVE_RESPONSE(
         "notifications.message_destination.active_response",
         BasicCounter()
+    ),
+    NOTIFICATIONS_MESSAGE_DESTINATION_ACTIVE_RESPONSE_BULK_FAILED(
+        "notifications.message_destination.active_response.bulk_failed",
+        RollingCounter()
     ), // add specific user errors for send message operations
 
     // Send Test Message Endpoints

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/ActiveResponseBulkIndexer.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/ActiveResponseBulkIndexer.kt
@@ -22,10 +22,13 @@ import java.util.concurrent.TimeUnit
  * Accumulates Active Response [IndexRequest]s and flushes them as a single [BulkRequest]
  * either when [flushIntervalMs] elapses (timeout-based) or [maxActions] is reached.
  *
- * Uses [BulkProcessor.builder(Client, Listener)] so the flush is scheduled on the client's
- * own thread pool without spinning up unmanaged threads. The [SecureIndexClient] wrapper
- * ensures each bulk request runs without an inherited security context, consistent with
- * all other direct-index operations in this plugin.
+ * Uses the explicit-scheduler [BulkProcessor.builder] overload, passing the plugin's
+ * own [org.opensearch.threadpool.ThreadPool] as the flush/retry scheduler. The simpler
+ * `builder(Client, Listener)` overload spawns an unmanaged scheduler thread that is
+ * blocked by the OpenSearch SecurityManager, causing the flush timer to silently
+ * never fire. The [SecureIndexClient] wrapper ensures each bulk request runs without
+ * an inherited security context, consistent with all other direct-index operations
+ * in this plugin.
  */
 internal class ActiveResponseBulkIndexer(
     client: Client,
@@ -35,7 +38,13 @@ internal class ActiveResponseBulkIndexer(
 
     private val log by logger(ActiveResponseBulkIndexer::class.java)
 
-    private val bulkProcessor: BulkProcessor = BulkProcessor.builder(SecureIndexClient(client), BulkListener())
+    private val bulkProcessor: BulkProcessor = BulkProcessor.builder(
+        SecureIndexClient(client),
+        BulkListener(),
+        client.threadPool(),
+        client.threadPool(),
+        Runnable { /* no-op: BulkProcessor close hook */ }
+    )
         .setFlushInterval(TimeValue.timeValueMillis(flushIntervalMs))
         .setBulkActions(maxActions)
         .setConcurrentRequests(1)

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/ActiveResponseBulkIndexer.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/ActiveResponseBulkIndexer.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.notifications.send
+
+import org.opensearch.action.bulk.BulkProcessor
+import org.opensearch.action.bulk.BulkRequest
+import org.opensearch.action.bulk.BulkResponse
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.common.unit.TimeValue
+import org.opensearch.commons.utils.logger
+import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
+import org.opensearch.notifications.metrics.Metrics
+import org.opensearch.notifications.util.SecureIndexClient
+import org.opensearch.transport.client.Client
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+
+/**
+ * Accumulates Active Response [IndexRequest]s and flushes them as a single [BulkRequest]
+ * either when [flushIntervalMs] elapses (timeout-based) or [maxActions] is reached.
+ *
+ * Uses [BulkProcessor.builder(Client, Listener)] so the flush is scheduled on the client's
+ * own thread pool without spinning up unmanaged threads. The [SecureIndexClient] wrapper
+ * ensures each bulk request runs without an inherited security context, consistent with
+ * all other direct-index operations in this plugin.
+ */
+internal class ActiveResponseBulkIndexer(
+    client: Client,
+    flushIntervalMs: Long,
+    maxActions: Int
+) : Closeable {
+
+    private val log by logger(ActiveResponseBulkIndexer::class.java)
+
+    private val bulkProcessor: BulkProcessor = BulkProcessor.builder(SecureIndexClient(client), BulkListener())
+        .setFlushInterval(TimeValue.timeValueMillis(flushIntervalMs))
+        .setBulkActions(maxActions)
+        .setConcurrentRequests(1)
+        .build()
+
+    fun add(request: IndexRequest) = bulkProcessor.add(request)
+
+    override fun close() {
+        bulkProcessor.awaitClose(10, TimeUnit.SECONDS)
+    }
+
+    private inner class BulkListener : BulkProcessor.Listener {
+        override fun beforeBulk(executionId: Long, request: BulkRequest) {
+            log.debug("$LOG_PREFIX:ActiveResponseBulkIndexer flushing ${request.numberOfActions()} action(s) (executionId=$executionId)")
+        }
+
+        override fun afterBulk(executionId: Long, request: BulkRequest, response: BulkResponse) {
+            if (response.hasFailures()) {
+                val failedItems = response.items.filter { it.isFailed }
+                log.error("$LOG_PREFIX:ActiveResponseBulkIndexer ${failedItems.size}/${request.numberOfActions()} item(s) failed (executionId=$executionId): ${response.buildFailureMessage()}")
+                repeat(failedItems.size) {
+                    Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_ACTIVE_RESPONSE_BULK_FAILED.counter.increment()
+                }
+            } else {
+                log.debug("$LOG_PREFIX:ActiveResponseBulkIndexer all ${request.numberOfActions()} item(s) succeeded (executionId=$executionId)")
+            }
+        }
+
+        override fun afterBulk(executionId: Long, request: BulkRequest, failure: Throwable) {
+            val count = request.numberOfActions()
+            log.error("$LOG_PREFIX:ActiveResponseBulkIndexer bulk dispatch failed for $count item(s) (executionId=$executionId)", failure)
+            repeat(count) {
+                Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_ACTIVE_RESPONSE_BULK_FAILED.counter.increment()
+            }
+        }
+    }
+}

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -332,7 +332,7 @@ object SendMessageActionHelper {
                 .source(documentToIndex)
             activeResponseBulkIndexer.add(indexRequest)
             log.debug("$LOG_PREFIX:sendActiveResponseMessage Queued active response for docId=$docId indexName=$indexName")
-            eventStatus.copy(deliveryStatus = DeliveryStatus(RestStatus.ACCEPTED.status.toString(), "Active response queued for bulk indexing"))
+            eventStatus.copy(deliveryStatus = DeliveryStatus(RestStatus.OK.status.toString(), "Active response queued for bulk indexing"))
         } catch (exception: Exception) {
             log.error("$LOG_PREFIX:sendActiveResponseMessage Failed to prepare active response document for docId=$docId indexName=$indexName", exception)
             eventStatus.copy(

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -68,11 +68,18 @@ object SendMessageActionHelper {
     private lateinit var configOperations: ConfigOperations
     private lateinit var userAccess: UserAccess
     private lateinit var client: org.opensearch.notifications.util.SecureIndexClient
+    private lateinit var activeResponseBulkIndexer: ActiveResponseBulkIndexer
 
-    fun initialize(configOperations: ConfigOperations, userAccess: UserAccess, client: org.opensearch.transport.client.Client) {
+    internal fun initialize(
+        configOperations: ConfigOperations,
+        userAccess: UserAccess,
+        client: org.opensearch.transport.client.Client,
+        activeResponseBulkIndexer: ActiveResponseBulkIndexer
+    ) {
         this.configOperations = configOperations
         this.userAccess = userAccess
         this.client = org.opensearch.notifications.util.SecureIndexClient(client)
+        this.activeResponseBulkIndexer = activeResponseBulkIndexer
     }
 
     /**
@@ -264,7 +271,9 @@ object SendMessageActionHelper {
     }
 
     /**
-     * Add active response trigger document to index.
+     * Enqueues an active response trigger document into the bulk indexer.
+     * Returns [RestStatus.ACCEPTED] immediately; the document is flushed to
+     * [wazuh-active-responses] asynchronously by [ActiveResponseBulkIndexer].
      */
     private fun sendActiveResponseMessage(
         activeResponse: ActiveResponse,
@@ -273,24 +282,23 @@ object SendMessageActionHelper {
         eventStatus: EventStatus,
         referenceId: String
     ): EventStatus {
-        val indexDestination = "wazuh-active-responses"
-        return try {
-            Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_ACTIVE_RESPONSE.counter.increment()
-            /* Get the docId and indexName that is passed in the textDescription of the message using the template {{ctx.alerts.0.related_doc_ids}}
-                example: document_id|indexName
-            */
-            val parts = _message.textDescription.split("|", limit = 2)
-            if (parts.size < 2 || parts[0].isBlank() || parts[1].isBlank()) {
-                return eventStatus.copy(
-                    deliveryStatus = DeliveryStatus(
-                        RestStatus.BAD_REQUEST.status.toString(),
-                        "Invalid active response payload. Expected format: docId|indexName"
-                    )
+        Metrics.NOTIFICATIONS_MESSAGE_DESTINATION_ACTIVE_RESPONSE.counter.increment()
+        /* Get the docId and indexName that is passed in the textDescription of the message using the template {{ctx.alerts.0.related_doc_ids}}
+            example: document_id|indexName
+        */
+        val parts = _message.textDescription.split("|", limit = 2)
+        if (parts.size < 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            return eventStatus.copy(
+                deliveryStatus = DeliveryStatus(
+                    RestStatus.BAD_REQUEST.status.toString(),
+                    "Invalid active response payload. Expected format: docId|indexName"
                 )
-            }
-            val docId = parts[0]
-            val indexName = parts[1]
+            )
+        }
+        val docId = parts[0]
+        val indexName = parts[1]
 
+        return try {
             // Retrieve only the wazuh sub-fields allowed by the strict mapping of wazuh-active-responses.
             // Do NOT copy the entire source document — index-specific fields (e.g. 'file' in wazuh-states-fim-files)
             // are not mapped here and would cause a StrictDynamicMappingException.
@@ -319,19 +327,18 @@ object SendMessageActionHelper {
                 "wazuh" to wazuhMap
             )
 
-            log.debug("$LOG_PREFIX:sendActiveResponseMessage Indexing document to $indexDestination: $documentToIndex")
-            val indexRequest = org.opensearch.action.index.IndexRequest(indexDestination)
+            val indexRequest = org.opensearch.action.index.IndexRequest("wazuh-active-responses")
                 .opType(org.opensearch.action.DocWriteRequest.OpType.CREATE)
                 .source(documentToIndex)
-            val indexResponse = client.index(indexRequest).actionGet()
-            log.info("$LOG_PREFIX:sendActiveResponseMessage Successfully indexed active response to $indexDestination for docId: $docId, indexName: $indexName, result: ${indexResponse.result}")
-            eventStatus.copy(deliveryStatus = DeliveryStatus(RestStatus.OK.status.toString(), "Active response indexed"))
+            activeResponseBulkIndexer.add(indexRequest)
+            log.debug("$LOG_PREFIX:sendActiveResponseMessage Queued active response for docId=$docId indexName=$indexName")
+            eventStatus.copy(deliveryStatus = DeliveryStatus(RestStatus.ACCEPTED.status.toString(), "Active response queued for bulk indexing"))
         } catch (exception: Exception) {
-            log.error("$LOG_PREFIX:sendActiveResponseMessage Failed to index active response to $indexDestination", exception)
+            log.error("$LOG_PREFIX:sendActiveResponseMessage Failed to prepare active response document for docId=$docId indexName=$indexName", exception)
             eventStatus.copy(
                 deliveryStatus = DeliveryStatus(
                     RestStatus.FAILED_DEPENDENCY.status.toString(),
-                    "Failed to index active response"
+                    "Failed to prepare active response document"
                 )
             )
         }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -134,17 +134,18 @@ internal object PluginSettings {
 
     /**
      * Bulk flush interval for active response indexing (ms).
-     * Note: changes take effect only after plugin restart (BulkProcessor does not support live reconfiguration).
+     * Read once at plugin startup. The value is fixed for the lifetime of the node —
+     * BulkProcessor does not support live reconfiguration, so this setting is NodeScope-only.
      */
-    @Volatile
     var activeResponseBulkFlushIntervalMs: Long = DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
+        private set
 
     /**
      * Maximum number of bulk actions before a forced flush for active response.
-     * Note: changes take effect only after plugin restart.
+     * Read once at plugin startup; see [activeResponseBulkFlushIntervalMs] for rationale.
      */
-    @Volatile
     var activeResponseBulkMaxActions: Int = DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS
+        private set
 
     private const val DECIMAL_RADIX: Int = 10
 
@@ -192,20 +193,20 @@ internal object PluginSettings {
         Dynamic
     )
 
+    // BulkProcessor does not support live reconfiguration of flushInterval / bulkActions,
+    // so these settings are NodeScope-only — they take effect on plugin/node startup only.
     val ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS: Setting<Long> = Setting.longSetting(
         ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY,
         DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
         MINIMUM_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
-        NodeScope,
-        Dynamic
+        NodeScope
     )
 
     val ACTIVE_RESPONSE_BULK_MAX_ACTIONS: Setting<Int> = Setting.intSetting(
         ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY,
         DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
         MINIMUM_ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
-        NodeScope,
-        Dynamic
+        NodeScope
     )
 
     val LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES: Setting<Boolean> = Setting.boolSetting(
@@ -330,16 +331,9 @@ internal object PluginSettings {
             log.debug("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -autoUpdatedTo-> $clusterDefaultItemsQueryCount")
             defaultItemsQueryCount = clusterDefaultItemsQueryCount
         }
-        val clusterActiveResponseBulkFlushIntervalMs = clusterService.clusterSettings.get(ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS)
-        if (clusterActiveResponseBulkFlushIntervalMs != null) {
-            log.debug("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY -autoUpdatedTo-> $clusterActiveResponseBulkFlushIntervalMs")
-            activeResponseBulkFlushIntervalMs = clusterActiveResponseBulkFlushIntervalMs
-        }
-        val clusterActiveResponseBulkMaxActions = clusterService.clusterSettings.get(ACTIVE_RESPONSE_BULK_MAX_ACTIONS)
-        if (clusterActiveResponseBulkMaxActions != null) {
-            log.debug("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY -autoUpdatedTo-> $clusterActiveResponseBulkMaxActions")
-            activeResponseBulkMaxActions = clusterActiveResponseBulkMaxActions
-        }
+        // ACTIVE_RESPONSE_BULK_* settings are NodeScope-only; they are read once in
+        // updateSettingValuesFromLocal at startup and cannot change at runtime, so
+        // there is no cluster-state listener to register here.
     }
 
     /**
@@ -361,14 +355,8 @@ internal object PluginSettings {
             defaultItemsQueryCount = it
             log.info("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -updatedTo-> $it")
         }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS) {
-            activeResponseBulkFlushIntervalMs = it
-            log.info("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY -updatedTo-> $it (restart required)")
-        }
-        clusterService.clusterSettings.addSettingsUpdateConsumer(ACTIVE_RESPONSE_BULK_MAX_ACTIONS) {
-            activeResponseBulkMaxActions = it
-            log.info("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY -updatedTo-> $it (restart required)")
-        }
+        // No update consumers for ACTIVE_RESPONSE_BULK_* — those settings are NodeScope-only
+        // and cannot change at runtime (BulkProcessor has no live-reconfig API).
     }
 
     // reset the settings values to default values for testing purpose

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -41,6 +41,21 @@ internal object PluginSettings {
     private const val GENERAL_KEY_PREFIX = "$KEY_PREFIX.general"
 
     /**
+     * Active response settings Key prefix.
+     */
+    private const val ACTIVE_RESPONSE_KEY_PREFIX = "$KEY_PREFIX.active_response"
+
+    /**
+     * Bulk flush interval for active response indexing (ms).
+     */
+    private const val ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY = "$ACTIVE_RESPONSE_KEY_PREFIX.bulk_flush_interval_ms"
+
+    /**
+     * Maximum number of bulk actions before a forced flush.
+     */
+    private const val ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY = "$ACTIVE_RESPONSE_KEY_PREFIX.bulk_max_actions"
+
+    /**
      * Operation timeout for network operations.
      */
     private const val OPERATION_TIMEOUT_MS_KEY = "$GENERAL_KEY_PREFIX.operation_timeout_ms"
@@ -86,6 +101,26 @@ internal object PluginSettings {
     private const val MINIMUM_ITEMS_QUERY_COUNT = 10
 
     /**
+     * Default bulk flush interval for active response (ms).
+     */
+    private const val DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS = 500L
+
+    /**
+     * Minimum bulk flush interval for active response (ms).
+     */
+    private const val MINIMUM_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS = 100L
+
+    /**
+     * Default maximum bulk actions before a forced flush.
+     */
+    private const val DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS = 1000
+
+    /**
+     * Minimum maximum bulk actions value.
+     */
+    private const val MINIMUM_ACTIVE_RESPONSE_BULK_MAX_ACTIONS = 1
+
+    /**
      * Operation timeout setting in ms for I/O operations
      */
     @Volatile
@@ -96,6 +131,20 @@ internal object PluginSettings {
      */
     @Volatile
     var defaultItemsQueryCount: Int
+
+    /**
+     * Bulk flush interval for active response indexing (ms).
+     * Note: changes take effect only after plugin restart (BulkProcessor does not support live reconfiguration).
+     */
+    @Volatile
+    var activeResponseBulkFlushIntervalMs: Long = DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
+
+    /**
+     * Maximum number of bulk actions before a forced flush for active response.
+     * Note: changes take effect only after plugin restart.
+     */
+    @Volatile
+    var activeResponseBulkMaxActions: Int = DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS
 
     private const val DECIMAL_RADIX: Int = 10
 
@@ -117,6 +166,10 @@ internal object PluginSettings {
         operationTimeoutMs = (settings?.get(OPERATION_TIMEOUT_MS_KEY)?.toLong()) ?: DEFAULT_OPERATION_TIMEOUT_MS
         defaultItemsQueryCount = (settings?.get(DEFAULT_ITEMS_QUERY_COUNT_KEY)?.toInt())
             ?: DEFAULT_ITEMS_QUERY_COUNT_VALUE
+        activeResponseBulkFlushIntervalMs = (settings?.get(ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY)?.toLong())
+            ?: DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
+        activeResponseBulkMaxActions = (settings?.get(ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY)?.toInt())
+            ?: DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS
         defaultSettings = mapOf(
             OPERATION_TIMEOUT_MS_KEY to operationTimeoutMs.toString(DECIMAL_RADIX),
             DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX)
@@ -135,6 +188,22 @@ internal object PluginSettings {
         DEFAULT_ITEMS_QUERY_COUNT_KEY,
         defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
         MINIMUM_ITEMS_QUERY_COUNT,
+        NodeScope,
+        Dynamic
+    )
+
+    val ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS: Setting<Long> = Setting.longSetting(
+        ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY,
+        DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+        MINIMUM_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+        NodeScope,
+        Dynamic
+    )
+
+    val ACTIVE_RESPONSE_BULK_MAX_ACTIONS: Setting<Int> = Setting.intSetting(
+        ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY,
+        DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
+        MINIMUM_ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
         NodeScope,
         Dynamic
     )
@@ -223,6 +292,8 @@ internal object PluginSettings {
         return listOf(
             OPERATION_TIMEOUT_MS,
             DEFAULT_ITEMS_QUERY_COUNT,
+            ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+            ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
             FILTER_BY_BACKEND_ROLES,
             MULTI_TENANCY_ENABLED,
             REMOTE_METADATA_REGION,
@@ -239,6 +310,8 @@ internal object PluginSettings {
     private fun updateSettingValuesFromLocal(clusterService: ClusterService) {
         operationTimeoutMs = OPERATION_TIMEOUT_MS.get(clusterService.settings)
         defaultItemsQueryCount = DEFAULT_ITEMS_QUERY_COUNT.get(clusterService.settings)
+        activeResponseBulkFlushIntervalMs = ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS.get(clusterService.settings)
+        activeResponseBulkMaxActions = ACTIVE_RESPONSE_BULK_MAX_ACTIONS.get(clusterService.settings)
     }
 
     /**
@@ -256,6 +329,16 @@ internal object PluginSettings {
         if (clusterDefaultItemsQueryCount != null) {
             log.debug("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -autoUpdatedTo-> $clusterDefaultItemsQueryCount")
             defaultItemsQueryCount = clusterDefaultItemsQueryCount
+        }
+        val clusterActiveResponseBulkFlushIntervalMs = clusterService.clusterSettings.get(ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS)
+        if (clusterActiveResponseBulkFlushIntervalMs != null) {
+            log.debug("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY -autoUpdatedTo-> $clusterActiveResponseBulkFlushIntervalMs")
+            activeResponseBulkFlushIntervalMs = clusterActiveResponseBulkFlushIntervalMs
+        }
+        val clusterActiveResponseBulkMaxActions = clusterService.clusterSettings.get(ACTIVE_RESPONSE_BULK_MAX_ACTIONS)
+        if (clusterActiveResponseBulkMaxActions != null) {
+            log.debug("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY -autoUpdatedTo-> $clusterActiveResponseBulkMaxActions")
+            activeResponseBulkMaxActions = clusterActiveResponseBulkMaxActions
         }
     }
 
@@ -278,6 +361,14 @@ internal object PluginSettings {
             defaultItemsQueryCount = it
             log.info("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -updatedTo-> $it")
         }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS) {
+            activeResponseBulkFlushIntervalMs = it
+            log.info("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY -updatedTo-> $it (restart required)")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ACTIVE_RESPONSE_BULK_MAX_ACTIONS) {
+            activeResponseBulkMaxActions = it
+            log.info("$LOG_PREFIX:$ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY -updatedTo-> $it (restart required)")
+        }
     }
 
     // reset the settings values to default values for testing purpose
@@ -285,5 +376,7 @@ internal object PluginSettings {
     fun reset() {
         operationTimeoutMs = DEFAULT_OPERATION_TIMEOUT_MS
         defaultItemsQueryCount = DEFAULT_ITEMS_QUERY_COUNT_VALUE
+        activeResponseBulkFlushIntervalMs = DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
+        activeResponseBulkMaxActions = DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS
     }
 }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
@@ -80,7 +80,9 @@ internal class PluginSettingsTests {
                 clusterSettings,
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
-                    PluginSettings.DEFAULT_ITEMS_QUERY_COUNT
+                    PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS
                 )
             )
         )
@@ -104,7 +106,9 @@ internal class PluginSettingsTests {
                 clusterSettings,
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
-                    PluginSettings.DEFAULT_ITEMS_QUERY_COUNT
+                    PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS
                 )
             )
         )
@@ -132,6 +136,8 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.FILTER_BY_BACKEND_ROLES
                 )
             )
@@ -155,6 +161,8 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES,
                     PluginSettings.ALERTING_FILTER_BY_BACKEND_ROLES,
                     PluginSettings.FILTER_BY_BACKEND_ROLES
@@ -179,6 +187,8 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES,
                     PluginSettings.ALERTING_FILTER_BY_BACKEND_ROLES,
                     PluginSettings.FILTER_BY_BACKEND_ROLES
@@ -202,6 +212,8 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
+                    PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES,
                     PluginSettings.ALERTING_FILTER_BY_BACKEND_ROLES,
                     PluginSettings.FILTER_BY_BACKEND_ROLES


### PR DESCRIPTION
### Description
Replaces the per-document `client.index()` call in the Active Response notification channel
with a `BulkProcessor`-based approach. Documents are now accumulated in a buffer and flushed
to `wazuh-active-responses` as a single bulk request either when the flush interval elapses
(timeout-based) or when the max-actions threshold is reached, whichever comes first.

**Changes:**
- New `ActiveResponseBulkIndexer` class wrapping `BulkProcessor` with `SecureIndexClient`
  to ensure security context is stripped on the scheduler thread, consistent with all other
  direct-index operations in the plugin.
- `sendActiveResponseMessage` returns `200 OK` immediately after enqueuing the document;
  indexing errors are handled asynchronously via `BulkProcessor.Listener` and surfaced through
  a new `notifications.message_destination.active_response.bulk_failed` rolling metric.
- Two new node-scoped cluster settings:
  - `opensearch.notifications.active_response.bulk_flush_interval_ms` (default: `500`)
  - `opensearch.notifications.active_response.bulk_max_actions` (default: `1000`)
- Plugin `close()` calls `bulkProcessor.awaitClose(10s)` to drain the buffer on shutdown.

> **Note:** Setting updates are stored but take effect only after a plugin restart,
> as `BulkProcessor` does not support live reconfiguration.


**Postman collection for validation:** [AR-Bulk-Indexing.json](https://github.com/user-attachments/files/27165777/Active.Response.Bulk.Indexing.Validation.via.Alerting.postman_collection.json)

### Related Issues
Closes #41 

### Check List
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
