### PR TITLE
Create default notification channels on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add active response channel [(#7)](https://github.com/wazuh/wazuh-indexer-notifications/pull/7)
 - Add `--set-as-main` flag support to repository bumper [(#23)](https://github.com/wazuh/wazuh-indexer-notifications/pull/23)
 - Add revert bump functionality to repository bumper workflow [(#58)](https://github.com/wazuh/wazuh-indexer-notifications/pull/58)
+- Create default notification channels on startup [(#68)](https://github.com/wazuh/wazuh-indexer-notifications/pull/68)
 
 ### Dependencies
 -

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -7,6 +7,7 @@ package org.opensearch.notifications
 
 import org.opensearch.action.ActionRequest
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
+import org.opensearch.cluster.node.DiscoveryNode
 import org.opensearch.cluster.node.DiscoveryNodes
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
@@ -32,6 +33,7 @@ import org.opensearch.notifications.action.SendNotificationAction
 import org.opensearch.notifications.action.SendTestNotificationAction
 import org.opensearch.notifications.action.UpdateNotificationConfigAction
 import org.opensearch.notifications.index.ConfigIndexingActions
+import org.opensearch.notifications.index.DefaultChannelInitializer
 import org.opensearch.notifications.index.NotificationConfigIndex
 import org.opensearch.notifications.resthandler.NotificationChannelListRestHandler
 import org.opensearch.notifications.resthandler.NotificationConfigRestHandler
@@ -49,6 +51,7 @@ import org.opensearch.notifications.spi.NotificationCore
 import org.opensearch.notifications.spi.NotificationCoreExtension
 import org.opensearch.notifications.util.SecureIndexClient
 import org.opensearch.plugins.ActionPlugin
+import org.opensearch.plugins.ClusterPlugin
 import org.opensearch.plugins.Plugin
 import org.opensearch.plugins.SystemIndexPlugin
 import org.opensearch.remote.metadata.client.impl.SdkClientFactory
@@ -70,7 +73,7 @@ import java.util.function.Supplier
  * Entry point of the OpenSearch Notifications plugin
  * This class initializes the rest handlers.
  */
-class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, SystemIndexPlugin {
+class NotificationPlugin : ActionPlugin, ClusterPlugin, Plugin(), NotificationCoreExtension, SystemIndexPlugin {
 
     lateinit var clusterService: ClusterService // initialized in createComponents()
 
@@ -208,5 +211,15 @@ class NotificationPlugin : ActionPlugin, Plugin(), NotificationCoreExtension, Sy
     override fun setNotificationCore(core: NotificationCore) {
         log.debug("$LOG_PREFIX:setNotificationCore")
         CoreProvider.initialize(core)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    override fun onNodeStarted(localNode: DiscoveryNode) {
+        if (localNode.isClusterManagerNode) {
+            log.info("$LOG_PREFIX:Initializing default notification channels on cluster manager node")
+            DefaultChannelInitializer.initialize()
+        }
     }
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.notifications.index
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.opensearch.commons.notifications.model.ConfigType
+import org.opensearch.commons.notifications.model.HttpMethodType
+import org.opensearch.commons.notifications.model.NotificationConfig
+import org.opensearch.commons.notifications.model.Slack
+import org.opensearch.commons.notifications.model.Webhook
+import org.opensearch.commons.utils.logger
+import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
+import org.opensearch.notifications.model.DocMetadata
+import org.opensearch.notifications.model.NotificationConfigDoc
+import java.time.Instant
+
+/**
+ * Creates default notification channels on startup if they don't already exist.
+ *
+ * These channels are created disabled with placeholder URLs so that users can
+ * configure them with their own credentials before enabling.
+ */
+object DefaultChannelInitializer {
+    private val log by logger(DefaultChannelInitializer::class.java)
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+
+    /** Default channel definitions matching the ones previously created by the Wazuh Dashboard. */
+    internal data class ChannelDefinition(
+        val id: String,
+        val config: NotificationConfig
+    )
+
+    internal val DEFAULT_CHANNELS: List<ChannelDefinition> = listOf(
+        ChannelDefinition(
+            id = "default_slack_channel",
+            config = NotificationConfig(
+                name = "Slack Channel",
+                description = "Default Slack notification channel. A sample monitor is created automatically. " +
+                    "Go to Alerting > Monitors to review it and configure this channel before enabling alerts.",
+                configType = ConfigType.SLACK,
+                isEnabled = false,
+                configData = Slack(
+                    url = "https://hooks.slack.com/services/YOUR_WORKSPACE_ID/YOUR_CHANNEL_ID/YOUR_WEBHOOK_TOKEN"
+                )
+            )
+        ),
+        ChannelDefinition(
+            id = "default_jira_channel",
+            config = NotificationConfig(
+                name = "Jira Channel",
+                description = "Default Jira notification channel.\n\n" +
+                    "Configure your Jira domain and authentication (use a Base64-encoded 'email:api_token' " +
+                    "in the Authorization header). A sample monitor is created automatically — go to " +
+                    "Alerting > Monitors to review it and enable the action once this channel is configured.",
+                configType = ConfigType.WEBHOOK,
+                isEnabled = false,
+                configData = Webhook(
+                    url = "https://your-domain.atlassian.net/rest/api/3/issue",
+                    headerParams = mapOf(
+                        "Content-Type" to "application/json",
+                        "Authorization" to "Basic base64(email:api_token)"
+                    ),
+                    method = HttpMethodType.POST
+                )
+            )
+        ),
+        ChannelDefinition(
+            id = "default_pagerduty_channel",
+            config = NotificationConfig(
+                name = "PagerDuty Channel",
+                description = "Default PagerDuty notification channel.\n\n" +
+                    "Configure a PagerDuty integration and set its Integration Key in the 'X-Routing-Key' " +
+                    "header below. A sample monitor is created automatically — go to Alerting > Monitors " +
+                    "to review it and enable the action once this channel is configured.",
+                configType = ConfigType.WEBHOOK,
+                isEnabled = false,
+                configData = Webhook(
+                    url = "https://events.pagerduty.com/v2/enqueue",
+                    headerParams = mapOf(
+                        "Content-Type" to "application/json",
+                        "X-Routing-Key" to "YOUR_PAGERDUTY_API_KEY"
+                    ),
+                    method = HttpMethodType.POST
+                )
+            )
+        ),
+        ChannelDefinition(
+            id = "default_shuffle_channel",
+            config = NotificationConfig(
+                name = "Shuffle Channel",
+                description = "Default Shuffle notification channel. A sample monitor is created automatically. " +
+                    "Go to Alerting > Monitors to review it and configure this channel before enabling workflows.",
+                configType = ConfigType.WEBHOOK,
+                isEnabled = false,
+                configData = Webhook(
+                    url = "https://shuffler.io/api/v1/hooks/WEBHOOK_ID",
+                    headerParams = mapOf(
+                        "Content-Type" to "application/json"
+                    ),
+                    method = HttpMethodType.POST
+                )
+            )
+        )
+    )
+
+    /**
+     * Initializes default notification channels asynchronously.
+     * Checks which channels already exist and creates only the missing ones.
+     * This method is idempotent and safe to call on every startup.
+     */
+    fun initialize() {
+        scope.launch {
+            try {
+                initializeDefaultChannels()
+            } catch (e: Exception) {
+                log.error("$LOG_PREFIX:Failed to initialize default notification channels", e)
+            }
+        }
+    }
+
+    /**
+     * Core initialization logic. Checks for existing channels and creates missing ones.
+     */
+    internal suspend fun initializeDefaultChannels() {
+        log.info("$LOG_PREFIX:Starting initialization of default notification channels")
+
+        val existingIds = getExistingDefaultChannelIds()
+        val missingChannels = DEFAULT_CHANNELS.filter { it.id !in existingIds }
+
+        if (missingChannels.isEmpty()) {
+            log.info("$LOG_PREFIX:All default notification channels already exist")
+            return
+        }
+
+        log.info("$LOG_PREFIX:Creating ${missingChannels.size} missing default notification channels")
+
+        var created = 0
+        for (channel in missingChannels) {
+            try {
+                createChannel(channel)
+                created++
+                log.info("$LOG_PREFIX:Created default notification channel: ${channel.config.name} (${channel.id})")
+            } catch (e: Exception) {
+                log.error(
+                    "$LOG_PREFIX:Failed to create default notification channel: ${channel.config.name} (${channel.id})",
+                    e
+                )
+            }
+        }
+
+        log.info("$LOG_PREFIX:Default notification channels initialization complete. Created $created/${missingChannels.size}")
+    }
+
+    /**
+     * Returns the set of default channel IDs that already exist in the index.
+     */
+    private suspend fun getExistingDefaultChannelIds(): Set<String> {
+        return try {
+            val defaultIds = DEFAULT_CHANNELS.map { it.id }.toSet()
+            val existing = NotificationConfigIndex.getNotificationConfigs(defaultIds)
+            existing.map { it.docInfo.id!! }.toSet()
+        } catch (e: Exception) {
+            // Index may not exist yet, or documents not found — treat as none existing
+            log.debug("$LOG_PREFIX:Could not check existing default channels: ${e.message}")
+            emptySet()
+        }
+    }
+
+    /**
+     * Creates a single default notification channel.
+     */
+    private suspend fun createChannel(channel: ChannelDefinition) {
+        val now = Instant.now()
+        val metadata = DocMetadata(
+            lastUpdateTime = now,
+            createdTime = now,
+            access = listOf() // Empty access list makes the channel public (visible to all users)
+        )
+        val configDoc = NotificationConfigDoc(metadata, channel.config)
+        NotificationConfigIndex.createNotificationConfig(configDoc, channel.id)
+    }
+}

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/index/DefaultChannelInitializerTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/index/DefaultChannelInitializerTests.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.notifications.index
+
+import org.junit.jupiter.api.Test
+import org.opensearch.commons.notifications.model.ConfigType
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DefaultChannelInitializerTests {
+
+    @Test
+    fun `test default channels are defined with correct IDs`() {
+        val ids = DefaultChannelInitializer.DEFAULT_CHANNELS.map { it.id }
+        assertTrue(ids.contains("default_slack_channel"), "Missing default_slack_channel")
+        assertTrue(ids.contains("default_jira_channel"), "Missing default_jira_channel")
+        assertTrue(ids.contains("default_pagerduty_channel"), "Missing default_pagerduty_channel")
+        assertTrue(ids.contains("default_shuffle_channel"), "Missing default_shuffle_channel")
+        assertEquals(4, ids.size, "Expected exactly 4 default channels")
+    }
+
+    @Test
+    fun `test default channels have unique IDs`() {
+        val ids = DefaultChannelInitializer.DEFAULT_CHANNELS.map { it.id }
+        assertEquals(ids.size, ids.toSet().size, "Default channel IDs must be unique")
+    }
+
+    @Test
+    fun `test all default channels are disabled`() {
+        DefaultChannelInitializer.DEFAULT_CHANNELS.forEach { channel ->
+            assertFalse(channel.config.isEnabled, "Channel ${channel.id} should be disabled by default")
+        }
+    }
+
+    @Test
+    fun `test slack channel has correct config type`() {
+        val slack = DefaultChannelInitializer.DEFAULT_CHANNELS.first { it.id == "default_slack_channel" }
+        assertEquals(ConfigType.SLACK, slack.config.configType, "Slack channel should have SLACK config type")
+    }
+
+    @Test
+    fun `test webhook channels have correct config type`() {
+        val webhookIds = listOf("default_jira_channel", "default_pagerduty_channel", "default_shuffle_channel")
+        webhookIds.forEach { id ->
+            val channel = DefaultChannelInitializer.DEFAULT_CHANNELS.first { it.id == id }
+            assertEquals(ConfigType.WEBHOOK, channel.config.configType, "$id should have WEBHOOK config type")
+        }
+    }
+
+    @Test
+    fun `test all default channels have non-empty names`() {
+        DefaultChannelInitializer.DEFAULT_CHANNELS.forEach { channel ->
+            assertTrue(channel.config.name.isNotEmpty(), "Channel ${channel.id} should have a non-empty name")
+        }
+    }
+
+    @Test
+    fun `test all default channels have non-empty descriptions`() {
+        DefaultChannelInitializer.DEFAULT_CHANNELS.forEach { channel ->
+            assertTrue(
+                channel.config.description.isNotEmpty(),
+                "Channel ${channel.id} should have a non-empty description"
+            )
+        }
+    }
+
+    @Test
+    fun `test all default channels have config data`() {
+        DefaultChannelInitializer.DEFAULT_CHANNELS.forEach { channel ->
+            assertTrue(
+                channel.config.configData != null,
+                "Channel ${channel.id} should have config data"
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR adds a default creation mechanism for the default channels that were previously created in the dashboard

Validation in https://github.com/wazuh/wazuh-indexer-notifications/issues/45#issuecomment-4328486031

### Related Issues
Resolves #45
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
