### PR TITLE
Disable license headers

### DIFF
--- a/.github/workflows/5_builderpackage_notifications_onpush.yml
+++ b/.github/workflows/5_builderpackage_notifications_onpush.yml
@@ -5,8 +5,6 @@ name: (5.x) Build packages (on push)
 
 on:
   push:
-    paths-ignore:
-      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/5_builderpackage_notifications_onpush.yml
+++ b/.github/workflows/5_builderpackage_notifications_onpush.yml
@@ -4,7 +4,10 @@ name: (5.x) Build packages (on push)
 # - On push
 
 on:
-  push:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+    paths-ignore:
+      - "**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -82,7 +82,7 @@ check.dependsOn jacocoTestReport
 
 // turn off javadoc as it barfs on Kotlin code
 javadoc.enabled = false
-licenseHeaders.enabled = true
+licenseHeaders.enabled = false
 // no need to validate pom, as we do not upload to maven/sonatype
 validateNebulaPom.enabled = false
 dependencyLicenses.enabled = false

--- a/notifications/notifications/build.gradle
+++ b/notifications/notifications/build.gradle
@@ -253,7 +253,7 @@ dependencies {
 
 // turn off javadoc as it barfs on Kotlin code
 javadoc.enabled = false
-licenseHeaders.enabled = true
+licenseHeaders.enabled = false
 // no need to validate pom, as we do not upload to maven/sonatype
 validateNebulaPom.enabled = false
 dependencyLicenses.enabled = false


### PR DESCRIPTION
### Description
This PR disables the licenses Header similar to other repos, so the build process don't fail using our header

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer/issues/1481

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
