### PR TITLE
Add safeguard to document already exists error in default channels

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -148,6 +148,7 @@ class NotificationPlugin : ActionPlugin, ClusterPlugin, Plugin(), NotificationCo
             PluginSettings.activeResponseBulkMaxActions
         )
         SendMessageActionHelper.initialize(NotificationConfigIndex, UserAccessManager, client, activeResponseBulkIndexer)
+        DefaultChannelInitializer.setClient(client)
         return listOf(sdkClient)
     }
 

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
@@ -19,8 +19,6 @@ package org.opensearch.notifications.index
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.opensearch.action.get.GetRequest
-import org.opensearch.action.get.GetResponse
 import org.opensearch.action.index.IndexRequest
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.notifications.model.ConfigType
@@ -157,30 +155,13 @@ object DefaultChannelInitializer {
     internal fun initializeDefaultChannels() {
         log.info("$LOG_PREFIX:Starting initialization of default notification channels")
 
-        val existingIds = getExistingDefaultChannelIds()
-        val missingChannels = DEFAULT_CHANNELS.filter { it.id !in existingIds }
-
-        if (missingChannels.isEmpty()) {
-            log.info("$LOG_PREFIX:All default notification channels already exist")
-            return
-        }
-
-        log.info("$LOG_PREFIX:Creating ${missingChannels.size} missing default notification channels")
-
-        var created = 0
-        var alreadyExisted = 0
-        for (channel in missingChannels) {
+        for (channel in DEFAULT_CHANNELS) {
             try {
                 createChannel(channel)
-                created++
-                log.info("$LOG_PREFIX:Created default notification channel: ${channel.config.name} (${channel.id})")
+                log.info("$LOG_PREFIX:Default notification channel [${channel.id}]: created")
             } catch (e: Exception) {
                 if (isVersionConflict(e)) {
-                    alreadyExisted++
-                    log.debug(
-                        "$LOG_PREFIX:Default notification channel already exists: " +
-                            "${channel.config.name} (${channel.id})"
-                    )
+                    log.info("$LOG_PREFIX:Default notification channel [${channel.id}]: already exists, ignored")
                 } else {
                     log.error(
                         "$LOG_PREFIX:Failed to create default notification channel: ${channel.config.name} (${channel.id})",
@@ -190,30 +171,7 @@ object DefaultChannelInitializer {
             }
         }
 
-        log.info(
-            "$LOG_PREFIX:Default notification channels initialization complete. " +
-                "Created: $created, already existed: $alreadyExisted, failed: ${missingChannels.size - created - alreadyExisted}"
-        )
-    }
-
-    /**
-     * Returns the set of default channel IDs that already exist in the index.
-     */
-    private fun getExistingDefaultChannelIds(): Set<String> {
-        val existingIds = mutableSetOf<String>()
-        for (channel in DEFAULT_CHANNELS) {
-            try {
-                val response: GetResponse = client.get(
-                    GetRequest(NotificationConfigIndex.INDEX_NAME, channel.id)
-                ).get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                if (response.isExists) {
-                    existingIds.add(channel.id)
-                }
-            } catch (e: Exception) {
-                log.debug("$LOG_PREFIX:Could not check if channel [${channel.id}] exists: ${e.message}")
-            }
-        }
-        return existingIds
+        log.info("$LOG_PREFIX:Default notification channels initialization complete")
     }
 
     /**

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
@@ -19,17 +19,24 @@ package org.opensearch.notifications.index
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import org.opensearch.OpenSearchStatusException
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.HttpMethodType
 import org.opensearch.commons.notifications.model.NotificationConfig
 import org.opensearch.commons.notifications.model.Slack
 import org.opensearch.commons.notifications.model.Webhook
 import org.opensearch.commons.utils.logger
+import org.opensearch.core.xcontent.ToXContent
+import org.opensearch.index.engine.VersionConflictEngineException
 import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
 import org.opensearch.notifications.model.DocMetadata
 import org.opensearch.notifications.model.NotificationConfigDoc
+import org.opensearch.transport.client.Client
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 /**
  * Creates default notification channels on startup if they don't already exist.
@@ -40,6 +47,15 @@ import java.time.Instant
 object DefaultChannelInitializer {
     private val log by logger(DefaultChannelInitializer::class.java)
     private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    private const val TIMEOUT_SECONDS = 30L
+    private lateinit var client: Client
+
+    /**
+     * Sets the OpenSearch client used for direct index operations.
+     */
+    fun setClient(client: Client) {
+        this.client = client
+    }
 
     /** Default channel definitions matching the ones previously created by the Wazuh Dashboard. */
     internal data class ChannelDefinition(
@@ -138,7 +154,7 @@ object DefaultChannelInitializer {
     /**
      * Core initialization logic. Checks for existing channels and creates missing ones.
      */
-    internal suspend fun initializeDefaultChannels() {
+    internal fun initializeDefaultChannels() {
         log.info("$LOG_PREFIX:Starting initialization of default notification channels")
 
         val existingIds = getExistingDefaultChannelIds()
@@ -152,6 +168,7 @@ object DefaultChannelInitializer {
         log.info("$LOG_PREFIX:Creating ${missingChannels.size} missing default notification channels")
 
         var created = 0
+        var alreadyExisted = 0
         for (channel in missingChannels) {
             try {
                 createChannel(channel)
@@ -159,8 +176,9 @@ object DefaultChannelInitializer {
                 log.info("$LOG_PREFIX:Created default notification channel: ${channel.config.name} (${channel.id})")
             } catch (e: Exception) {
                 if (isVersionConflict(e)) {
+                    alreadyExisted++
                     log.debug(
-                        "$LOG_PREFIX:Default notification channel already exists (concurrent creation): " +
+                        "$LOG_PREFIX:Default notification channel already exists: " +
                             "${channel.config.name} (${channel.id})"
                     )
                 } else {
@@ -172,47 +190,63 @@ object DefaultChannelInitializer {
             }
         }
 
-        log.info("$LOG_PREFIX:Default notification channels initialization complete. Created $created/${missingChannels.size}")
+        log.info(
+            "$LOG_PREFIX:Default notification channels initialization complete. " +
+                "Created: $created, already existed: $alreadyExisted, failed: ${missingChannels.size - created - alreadyExisted}"
+        )
     }
 
     /**
      * Returns the set of default channel IDs that already exist in the index.
      */
-    private suspend fun getExistingDefaultChannelIds(): Set<String> {
-        return try {
-            val defaultIds = DEFAULT_CHANNELS.map { it.id }.toSet()
-            val existing = NotificationConfigIndex.getNotificationConfigs(defaultIds)
-            existing.map { it.docInfo.id!! }.toSet()
-        } catch (e: Exception) {
-            // Index may not exist yet, or documents not found — treat as none existing
-            log.debug("$LOG_PREFIX:Could not check existing default channels: ${e.message}")
-            emptySet()
+    private fun getExistingDefaultChannelIds(): Set<String> {
+        val existingIds = mutableSetOf<String>()
+        for (channel in DEFAULT_CHANNELS) {
+            try {
+                val response: GetResponse = client.get(
+                    GetRequest(NotificationConfigIndex.INDEX_NAME, channel.id)
+                ).get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                if (response.isExists) {
+                    existingIds.add(channel.id)
+                }
+            } catch (e: Exception) {
+                log.debug("$LOG_PREFIX:Could not check if channel [${channel.id}] exists: ${e.message}")
+            }
         }
+        return existingIds
     }
 
     /**
-     * Checks whether the exception is caused by a version conflict (document already exists).
-     * This can happen in multi-node clusters where two nodes race to create the same channel.
+     * Checks whether the exception (or any cause in its chain) is a VersionConflictEngineException.
      */
     private fun isVersionConflict(e: Exception): Boolean {
-        val message = e.message ?: ""
-        if (message.contains("version conflict", ignoreCase = true)) return true
-        val cause = e.cause
-        if (cause is OpenSearchStatusException && cause.message?.contains("version conflict", ignoreCase = true) == true) return true
+        var current: Throwable? = e
+        while (current != null) {
+            if (current is VersionConflictEngineException) return true
+            current = current.cause
+        }
         return false
     }
 
     /**
      * Creates a single default notification channel.
      */
-    private suspend fun createChannel(channel: ChannelDefinition) {
+    private fun createChannel(channel: ChannelDefinition) {
         val now = Instant.now()
         val metadata = DocMetadata(
             lastUpdateTime = now,
             createdTime = now,
-            access = listOf() // Empty access list makes the channel public (visible to all users)
+            access = listOf()
         )
         val configDoc = NotificationConfigDoc(metadata, channel.config)
-        NotificationConfigIndex.createNotificationConfig(configDoc, channel.id)
+        val builder = XContentFactory.jsonBuilder()
+        configDoc.toXContent(builder, ToXContent.EMPTY_PARAMS)
+
+        val indexRequest = IndexRequest(NotificationConfigIndex.INDEX_NAME)
+            .id(channel.id)
+            .source(builder)
+            .create(true)
+
+        client.index(indexRequest).get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
     }
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
@@ -19,6 +19,8 @@ package org.opensearch.notifications.index
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest
+import org.opensearch.action.get.GetRequest
 import org.opensearch.action.index.IndexRequest
 import org.opensearch.common.xcontent.XContentFactory
 import org.opensearch.commons.notifications.model.ConfigType
@@ -49,7 +51,7 @@ object DefaultChannelInitializer {
     private lateinit var client: Client
 
     /**
-     * Sets the OpenSearch client used for direct index operations.
+     * Sets the OpenSearch client used for existence checks.
      */
     fun setClient(client: Client) {
         this.client = client
@@ -150,17 +152,32 @@ object DefaultChannelInitializer {
     }
 
     /**
-     * Core initialization logic. Checks for existing channels and creates missing ones.
+     * Core initialization logic.
+     *
+     * If the index does not exist yet (first startup), channels are created through
+     * [NotificationConfigIndex] which handles index creation with proper mappings.
+     * If the index already exists (subsequent restarts), channels are managed directly
+     * through the OpenSearch client for a lightweight, silent operation.
      */
-    internal fun initializeDefaultChannels() {
+    internal suspend fun initializeDefaultChannels() {
         log.info("$LOG_PREFIX:Starting initialization of default notification channels")
 
+        val indexExists = indexExists()
+
         for (channel in DEFAULT_CHANNELS) {
+            if (indexExists && channelExists(channel.id)) {
+                log.info("$LOG_PREFIX:Default notification channel [${channel.id}]: already exists, ignored")
+                continue
+            }
             try {
-                createChannel(channel)
+                if (indexExists) {
+                    insertChannel(channel)
+                } else {
+                    createChannelWithIndex(channel)
+                }
                 log.info("$LOG_PREFIX:Default notification channel [${channel.id}]: created")
             } catch (e: Exception) {
-                if (isVersionConflict(e)) {
+                if (isDocumentAlreadyExists(e)) {
                     log.info("$LOG_PREFIX:Default notification channel [${channel.id}]: already exists, ignored")
                 } else {
                     log.error(
@@ -175,9 +192,11 @@ object DefaultChannelInitializer {
     }
 
     /**
-     * Checks whether the exception (or any cause in its chain) is a VersionConflictEngineException.
+     * Checks whether the exception indicates the document already exists.
+     * This can happen when the index is still recovering and the existence check
+     * returns a false negative, but the subsequent insert finds the document.
      */
-    private fun isVersionConflict(e: Exception): Boolean {
+    private fun isDocumentAlreadyExists(e: Exception): Boolean {
         var current: Throwable? = e
         while (current != null) {
             if (current is VersionConflictEngineException) return true
@@ -187,16 +206,49 @@ object DefaultChannelInitializer {
     }
 
     /**
-     * Creates a single default notification channel.
+     * Checks whether the notifications config index exists.
      */
-    private fun createChannel(channel: ChannelDefinition) {
-        val now = Instant.now()
-        val metadata = DocMetadata(
-            lastUpdateTime = now,
-            createdTime = now,
-            access = listOf()
-        )
-        val configDoc = NotificationConfigDoc(metadata, channel.config)
+    private fun indexExists(): Boolean {
+        return try {
+            client.admin().indices()
+                .exists(IndicesExistsRequest(NotificationConfigIndex.INDEX_NAME))
+                .get(TIMEOUT_SECONDS, TimeUnit.SECONDS).isExists
+        } catch (e: Exception) {
+            log.debug("$LOG_PREFIX:Could not check if index exists: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Checks whether a channel document already exists in the index.
+     */
+    private fun channelExists(id: String): Boolean {
+        return try {
+            client.get(
+                GetRequest(NotificationConfigIndex.INDEX_NAME, id)
+            ).get(TIMEOUT_SECONDS, TimeUnit.SECONDS).isExists
+        } catch (e: Exception) {
+            log.debug("$LOG_PREFIX:Could not check if channel [$id] exists: ${e.message}")
+            false
+        }
+    }
+
+    /**
+     * Creates a channel through [NotificationConfigIndex], which ensures the index
+     * is created with the correct mappings. Used on first startup when the index
+     * does not exist yet.
+     */
+    private suspend fun createChannelWithIndex(channel: ChannelDefinition) {
+        val configDoc = buildConfigDoc(channel)
+        NotificationConfigIndex.createNotificationConfig(configDoc, channel.id)
+    }
+
+    /**
+     * Inserts a channel document directly into the existing index.
+     * Uses OpType.CREATE to fail gracefully if the document already exists.
+     */
+    private fun insertChannel(channel: ChannelDefinition) {
+        val configDoc = buildConfigDoc(channel)
         val builder = XContentFactory.jsonBuilder()
         configDoc.toXContent(builder, ToXContent.EMPTY_PARAMS)
 
@@ -206,5 +258,18 @@ object DefaultChannelInitializer {
             .create(true)
 
         client.index(indexRequest).get(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    }
+
+    /**
+     * Builds a NotificationConfigDoc for the given channel definition.
+     */
+    private fun buildConfigDoc(channel: ChannelDefinition): NotificationConfigDoc {
+        val now = Instant.now()
+        val metadata = DocMetadata(
+            lastUpdateTime = now,
+            createdTime = now,
+            access = listOf()
+        )
+        return NotificationConfigDoc(metadata, channel.config)
     }
 }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/DefaultChannelInitializer.kt
@@ -19,6 +19,7 @@ package org.opensearch.notifications.index
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import org.opensearch.OpenSearchStatusException
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.HttpMethodType
 import org.opensearch.commons.notifications.model.NotificationConfig
@@ -157,10 +158,17 @@ object DefaultChannelInitializer {
                 created++
                 log.info("$LOG_PREFIX:Created default notification channel: ${channel.config.name} (${channel.id})")
             } catch (e: Exception) {
-                log.error(
-                    "$LOG_PREFIX:Failed to create default notification channel: ${channel.config.name} (${channel.id})",
-                    e
-                )
+                if (isVersionConflict(e)) {
+                    log.debug(
+                        "$LOG_PREFIX:Default notification channel already exists (concurrent creation): " +
+                            "${channel.config.name} (${channel.id})"
+                    )
+                } else {
+                    log.error(
+                        "$LOG_PREFIX:Failed to create default notification channel: ${channel.config.name} (${channel.id})",
+                        e
+                    )
+                }
             }
         }
 
@@ -180,6 +188,18 @@ object DefaultChannelInitializer {
             log.debug("$LOG_PREFIX:Could not check existing default channels: ${e.message}")
             emptySet()
         }
+    }
+
+    /**
+     * Checks whether the exception is caused by a version conflict (document already exists).
+     * This can happen in multi-node clusters where two nodes race to create the same channel.
+     */
+    private fun isVersionConflict(e: Exception): Boolean {
+        val message = e.message ?: ""
+        if (message.contains("version conflict", ignoreCase = true)) return true
+        val cause = e.cause
+        if (cause is OpenSearchStatusException && cause.message?.contains("version conflict", ignoreCase = true) == true) return true
+        return false
     }
 
     /**


### PR DESCRIPTION
### Description
This PR logs the error of a `document already exists` instead of throwing an error so then if the documents already exist the error does not appear

## Validation
``` console
root@default:/home/vagrant# sudo grep -i "default.*notification\|version conflict\|DefaultChannel" /var/log/wazuh-indexer/wazuh-cluster.log | tail -20
[2026-05-08T15:25:03,688][INFO ][o.o.n.NotificationPlugin ] [indexer] notifications:Initializing default notification channels on cluster manager node
[2026-05-08T15:25:03,706][INFO ][o.o.n.i.DefaultChannelInitializer] [indexer] notifications:Starting initialization of default notification channels
[2026-05-08T15:25:04,910][INFO ][o.o.n.i.DefaultChannelInitializer] [indexer] notifications:Default notification channel [default_slack_channel]: already exists, ignored
[2026-05-08T15:25:04,912][INFO ][o.o.n.i.DefaultChannelInitializer] [indexer] notifications:Default notification channel [default_jira_channel]: already exists, ignored
[2026-05-08T15:25:04,917][INFO ][o.o.n.i.DefaultChannelInitializer] [indexer] notifications:Default notification channel [default_pagerduty_channel]: already exists, ignored
[2026-05-08T15:25:04,936][INFO ][o.o.n.i.DefaultChannelInitializer] [indexer] notifications:Default notification channel [default_shuffle_channel]: already exists, ignored
[2026-05-08T15:25:04,936][INFO ][o.o.n.i.DefaultChannelInitializer] [indexer] notifications:Default notification channels initialization complete

```

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-notifications/issues/99

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
