### PR TITLE
Active Response Events Completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Implement batch Active Response indexing using BulkProcessor [(#67)](https://github.com/wazuh/wazuh-indexer-notifications/pull/67)
 - Add revert bump functionality to repository bumper workflow [(#58)](https://github.com/wazuh/wazuh-indexer-notifications/pull/58)
 - Create default notification channels on startup [(#68)](https://github.com/wazuh/wazuh-indexer-notifications/pull/68)
+- Active Response events completeness [(#105)](https://github.com/wazuh/wazuh-indexer-notifications/pull/105)
 
 ### Dependencies
 -

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/send/SendMessageActionHelper.kt
@@ -299,14 +299,11 @@ object SendMessageActionHelper {
         val indexName = parts[1]
 
         return try {
-            // Retrieve only the wazuh sub-fields allowed by the strict mapping of wazuh-active-responses.
-            // Do NOT copy the entire source document — index-specific fields (e.g. 'file' in wazuh-states-fim-files)
-            // are not mapped here and would cause a StrictDynamicMappingException.
+            // Preserve the full wazuh object from the source document so the active response event
+            // contains the same wazuh payload as the original event.
             val sourceDocument = getSourceDocument(docId, indexName)
-            val allowedWazuhKeys = setOf("agent", "cluster", "integration", "protocol", "schema", "space")
             val wazuhMap = (sourceDocument["wazuh"] as? Map<*, *>)
                 ?.entries
-                ?.filter { it.key.toString() in allowedWazuhKeys }
                 ?.associate { it.key.toString() to it.value }
                 ?.toMutableMap()
                 ?: mutableMapOf()

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -253,104 +253,135 @@ internal class PluginActionTests {
     @Test
     fun `Send active response message should preserve full wazuh object`() {
         val wazuhObject = mapOf<String, Any?>(
+            "cluster" to mapOf<String, Any?>(
+                "node" to "node01",
+                "name" to "wazuh"
+            ),
+            "protocol" to mapOf<String, Any?>(
+                "location" to "syscheck",
+                "queue" to 56
+            ),
             "agent" to mapOf<String, Any?>(
-                "build" to emptyMap<String, Any?>(),
                 "host" to mapOf<String, Any?>(
-                    "boot" to emptyMap<String, Any?>(),
-                    "cpu" to emptyMap<String, Any?>(),
-                    "disk" to mapOf<String, Any?>(
-                        "read" to emptyMap<String, Any?>(),
-                        "write" to emptyMap<String, Any?>()
+                    "hostname" to "primary",
+                    "os" to mapOf<String, Any?>(
+                        "name" to "Ubuntu",
+                        "type" to "linux",
+                        "version" to "22.04.3 LTS (Jammy Jellyfish)",
+                        "platform" to "ubuntu"
                     ),
-                    "geo" to emptyMap<String, Any?>(),
-                    "memory" to mapOf<String, Any?>("used" to emptyMap<String, Any?>()),
-                    "network" to mapOf<String, Any?>(
-                        "egress" to emptyMap<String, Any?>(),
-                        "ingress" to emptyMap<String, Any?>()
+                    "architecture" to "x86_64"
+                ),
+                "name" to "primary",
+                "groups" to listOf("default"),
+                "id" to "001",
+                "version" to "v5.0.0"
+            ),
+            "integration" to mapOf<String, Any?>(
+                "name" to "wazuh-fim",
+                "decoders" to listOf(
+                    "decoder/core-wazuh-message/0",
+                    "decoder/wazuh-fim/0"
+                ),
+                "category" to "system-activity"
+            ),
+            "rule" to mapOf<String, Any?>(
+                "sigma_id" to "95cbac32-7a12-4b63-b85d-0a4d598b74e9",
+                "level" to "low",
+                "compliance" to mapOf<String, Any?>(
+                    "iso_27001" to listOf("A.12.4.1", "A.12.6.1", "A.16.1.2"),
+                    "hipaa" to listOf("164.308.a.1.ii.D", "164.308.a.6", "164.312.b"),
+                    "pci_dss" to listOf("6.2", "10.5", "11.4"),
+                    "tsc" to listOf("A1.2", "CC7.2", "CC7.3"),
+                    "nis2" to listOf("21.2.a", "21.2.e", "23"),
+                    "nist_800_171" to listOf("3.3.1", "3.3.2", "3.4.1", "3.14.6", "3.14.7"),
+                    "fedramp" to listOf("AU-6", "CM-6", "SI-4"),
+                    "nist_800_53" to listOf("AU-6", "CM-6", "SI-4"),
+                    "cmmc" to listOf("AU.L2-3.3.1", "CM.L2-3.4.1", "SI.L2-3.14.1"),
+                    "gdpr" to listOf("IV_32.1.a", "IV_33.1")
+                ),
+                "mitre" to mapOf<String, Any?>(
+                    "technique" to listOf("T1105", "T1036"),
+                    "tactic" to listOf("TA0003", "TA0005")
+                ),
+                "id" to "95cbac32-7a12-4b63-b85d-0a4d598b74e9",
+                "title" to "Wazuh FIM - File created",
+                "tags" to listOf(
+                    "low",
+                    "wazuh-fim",
+                    "attack.persistence",
+                    "attack.defense-evasion",
+                    "attack.t1105",
+                    "attack.t1036"
+                ),
+                "status" to "stable"
+            ),
+            "threat" to mapOf<String, Any?>(
+                "enrichments" to listOf(
+                    mapOf<String, Any?>(
+                        "indicator" to mapOf<String, Any?>(
+                            "feed" to mapOf<String, Any?>("name" to "wazuh-custom"),
+                            "first_seen" to "2026-03-31T00:00:00.000Z",
+                            "last_seen" to "2026-03-31T00:00:00.000Z",
+                            "software" to mapOf<String, Any?>(
+                                "name" to "eicar_test_file",
+                                "alias" to listOf("EICAR Test File", "AntiVirus Test File"),
+                                "type" to "test"
+                            ),
+                            "provider" to "wazuh",
+                            "confidence" to 100,
+                            "name" to "44d88612fea8a8f36de82e1278abb02f",
+                            "id" to "9999991",
+                            "type" to "hash_md5",
+                            "tags" to listOf("eicar", "test", "antivirus", "safe-test")
+                        ),
+                        "matched" to mapOf<String, Any?>("field" to "file.hash.md5")
                     ),
-                    "os" to emptyMap<String, Any?>(),
-                    "risk" to emptyMap<String, Any?>()
+                    mapOf<String, Any?>(
+                        "indicator" to mapOf<String, Any?>(
+                            "feed" to mapOf<String, Any?>("name" to "wazuh-custom"),
+                            "first_seen" to "2026-03-31T00:00:00.000Z",
+                            "last_seen" to "2026-03-31T00:00:00.000Z",
+                            "software" to mapOf<String, Any?>(
+                                "name" to "eicar_test_file",
+                                "alias" to listOf("EICAR Test File", "AntiVirus Test File"),
+                                "type" to "test"
+                            ),
+                            "provider" to "wazuh",
+                            "confidence" to 100,
+                            "name" to "3395856ce81f2b7382dee72602f798b642f14140",
+                            "id" to "9999992",
+                            "type" to "hash_sha1",
+                            "tags" to listOf("eicar", "test", "antivirus", "safe-test")
+                        ),
+                        "matched" to mapOf<String, Any?>("field" to "file.hash.sha1")
+                    ),
+                    mapOf<String, Any?>(
+                        "indicator" to mapOf<String, Any?>(
+                            "feed" to mapOf<String, Any?>("name" to "wazuh-custom"),
+                            "first_seen" to "2026-03-31T00:00:00.000Z",
+                            "last_seen" to "2026-03-31T00:00:00.000Z",
+                            "software" to mapOf<String, Any?>(
+                                "name" to "eicar_test_file",
+                                "alias" to listOf("EICAR Test File", "AntiVirus Test File"),
+                                "type" to "test"
+                            ),
+                            "provider" to "wazuh",
+                            "confidence" to 100,
+                            "name" to "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+                            "id" to "9999990",
+                            "type" to "hash_sha256",
+                            "tags" to listOf("eicar", "test", "antivirus", "safe-test")
+                        ),
+                        "matched" to mapOf<String, Any?>("field" to "file.hash.sha256")
+                    )
                 )
             ),
-            "cluster" to emptyMap<String, Any?>(),
-            "event" to emptyMap<String, Any?>(),
-            "integration" to emptyMap<String, Any?>(),
-            "protocol" to emptyMap<String, Any?>(),
-            "schema" to emptyMap<String, Any?>(),
-            "space" to emptyMap<String, Any?>(),
-            "threat" to mapOf<String, Any?>(
-                "enrichments" to mapOf<String, Any?>(
-                    "indicator" to mapOf<String, Any?>(
-                        "as" to mapOf<String, Any?>(
-                            "organization" to emptyMap<String, Any?>()
-                        ),
-                        "email" to emptyMap<String, Any?>(),
-                        "feed" to emptyMap<String, Any?>(),
-                        "file" to mapOf<String, Any?>(
-                            "code_signature" to emptyMap<String, Any?>(),
-                            "elf" to mapOf<String, Any?>(
-                                "header" to emptyMap<String, Any?>(),
-                                "sections" to emptyMap<String, Any?>(),
-                                "segments" to emptyMap<String, Any?>()
-                            ),
-                            "hash" to emptyMap<String, Any?>(),
-                            "pe" to mapOf<String, Any?>(
-                                "sections" to emptyMap<String, Any?>()
-                            ),
-                            "x509" to mapOf<String, Any?>(
-                                "issuer" to emptyMap<String, Any?>(),
-                                "subject" to emptyMap<String, Any?>()
-                            )
-                        ),
-                        "geo" to emptyMap<String, Any?>(),
-                        "marking" to emptyMap<String, Any?>(),
-                        "registry" to mapOf<String, Any?>(
-                            "data" to emptyMap<String, Any?>()
-                        ),
-                        "software" to emptyMap<String, Any?>(),
-                        "x509" to mapOf<String, Any?>(
-                            "issuer" to emptyMap<String, Any?>(),
-                            "subject" to emptyMap<String, Any?>()
-                        )
-                    ),
-                    "matched" to emptyMap<String, Any?>()
-                ),
-                "feed" to emptyMap<String, Any?>(),
-                "group" to emptyMap<String, Any?>(),
-                "indicator" to mapOf<String, Any?>(
-                    "as" to mapOf<String, Any?>(
-                        "organization" to emptyMap<String, Any?>()
-                    ),
-                    "email" to emptyMap<String, Any?>(),
-                    "file" to mapOf<String, Any?>(
-                        "code_signature" to emptyMap<String, Any?>(),
-                        "elf" to mapOf<String, Any?>(
-                            "header" to emptyMap<String, Any?>(),
-                            "sections" to emptyMap<String, Any?>(),
-                            "segments" to emptyMap<String, Any?>()
-                        ),
-                        "hash" to emptyMap<String, Any?>(),
-                        "pe" to mapOf<String, Any?>(
-                            "sections" to emptyMap<String, Any?>()
-                        ),
-                        "x509" to mapOf<String, Any?>(
-                            "issuer" to emptyMap<String, Any?>(),
-                            "subject" to emptyMap<String, Any?>()
-                        )
-                    ),
-                    "geo" to emptyMap<String, Any?>(),
-                    "marking" to emptyMap<String, Any?>(),
-                    "registry" to mapOf<String, Any?>(
-                        "data" to emptyMap<String, Any?>()
-                    ),
-                    "x509" to mapOf<String, Any?>(
-                        "issuer" to emptyMap<String, Any?>(),
-                        "subject" to emptyMap<String, Any?>()
-                    )
-                ),
-                "software" to emptyMap<String, Any?>(),
-                "tactic" to emptyMap<String, Any?>(),
-                "technique" to mapOf<String, Any?>("subtechnique" to emptyMap<String, Any?>())
+            "event" to mapOf<String, Any?>(
+                "id" to "285c2315-f92d-4ba7-ab87-fbe3a31ee378"
+            ),
+            "space" to mapOf<String, Any?>(
+                "name" to "standard"
             )
         )
 
@@ -398,10 +429,13 @@ internal class PluginActionTests {
         assertTrue(indexRequestSlot.isCaptured)
 
         val indexedSource = indexRequestSlot.captured.source().utf8ToString()
-        assertTrue(indexedSource.contains("\"file\""), "expected wazuh.file to be preserved")
         assertTrue(indexedSource.contains("\"agent\""), "expected wazuh.agent to be preserved")
+        assertTrue(indexedSource.contains("\"syscheck\""), "expected wazuh.protocol.location to be preserved")
+        assertTrue(indexedSource.contains("\"rule\""), "expected wazuh.rule to be preserved")
+        assertTrue(indexedSource.contains("95cbac32-7a12-4b63-b85d-0a4d598b74e9"), "expected wazuh.rule.sigma_id to be preserved")
         assertTrue(indexedSource.contains("\"threat\""), "expected wazuh.threat to be preserved")
-        assertTrue(indexedSource.contains("\"technique\""), "expected wazuh.technique to be preserved")
+        assertTrue(indexedSource.contains("\"hash_sha256\""), "expected wazuh.threat.enrichments indicator data to be preserved")
+        assertTrue(indexedSource.contains("\"file.hash.sha256\""), "expected wazuh.threat.enrichments.matched.field to be preserved")
         assertTrue(indexedSource.contains("\"active_response\""), "expected active_response block to be present")
         assertTrue(indexedSource.contains("\"doc_id\":\"doc-1\""))
     }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/action/PluginActionTests.kt
@@ -5,7 +5,9 @@
 package org.opensearch.notifications.action
 
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -14,7 +16,11 @@ import org.mockito.Answers
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.opensearch.action.bulk.BulkProcessor
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.index.IndexRequest
 import org.opensearch.action.support.ActionFilters
+import org.opensearch.common.action.ActionFuture
 import org.opensearch.commons.destination.response.LegacyDestinationResponse
 import org.opensearch.commons.notifications.action.BaseResponse
 import org.opensearch.commons.notifications.action.CreateNotificationConfigRequest
@@ -33,6 +39,7 @@ import org.opensearch.commons.notifications.action.SendNotificationRequest
 import org.opensearch.commons.notifications.action.SendNotificationResponse
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigRequest
 import org.opensearch.commons.notifications.action.UpdateNotificationConfigResponse
+import org.opensearch.commons.notifications.model.ActiveResponse
 import org.opensearch.commons.notifications.model.ChannelList
 import org.opensearch.commons.notifications.model.ConfigType
 import org.opensearch.commons.notifications.model.DeliveryStatus
@@ -45,11 +52,17 @@ import org.opensearch.core.action.ActionListener
 import org.opensearch.core.rest.RestStatus
 import org.opensearch.core.xcontent.NamedXContentRegistry
 import org.opensearch.notifications.index.ConfigIndexingActions
+import org.opensearch.notifications.send.ActiveResponseBulkIndexer
 import org.opensearch.notifications.send.SendMessageActionHelper
+import org.opensearch.notifications.spi.model.MessageContent
+import org.opensearch.notifications.util.SecureIndexClient
 import org.opensearch.tasks.Task
 import org.opensearch.transport.TransportService
 import org.opensearch.transport.client.Client
+import java.lang.reflect.Field
+import java.lang.reflect.Method
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @ExtendWith(MockitoExtension::class)
 internal class PluginActionTests {
@@ -202,7 +215,6 @@ internal class PluginActionTests {
 
     @Test
     fun `Send notification action should call back action listener`() {
-        val notificationId = "notification-1"
         val request = mock(SendNotificationRequest::class.java)
 
         val sampleEventSource = EventSource(
@@ -236,6 +248,162 @@ internal class PluginActionTests {
             xContentRegistry
         )
         sendNotificationAction.execute(task, request, AssertionListener(response))
+    }
+
+    @Test
+    fun `Send active response message should preserve full wazuh object`() {
+        val wazuhObject = mapOf<String, Any?>(
+            "agent" to mapOf<String, Any?>(
+                "build" to emptyMap<String, Any?>(),
+                "host" to mapOf<String, Any?>(
+                    "boot" to emptyMap<String, Any?>(),
+                    "cpu" to emptyMap<String, Any?>(),
+                    "disk" to mapOf<String, Any?>(
+                        "read" to emptyMap<String, Any?>(),
+                        "write" to emptyMap<String, Any?>()
+                    ),
+                    "geo" to emptyMap<String, Any?>(),
+                    "memory" to mapOf<String, Any?>("used" to emptyMap<String, Any?>()),
+                    "network" to mapOf<String, Any?>(
+                        "egress" to emptyMap<String, Any?>(),
+                        "ingress" to emptyMap<String, Any?>()
+                    ),
+                    "os" to emptyMap<String, Any?>(),
+                    "risk" to emptyMap<String, Any?>()
+                )
+            ),
+            "cluster" to emptyMap<String, Any?>(),
+            "event" to emptyMap<String, Any?>(),
+            "integration" to emptyMap<String, Any?>(),
+            "protocol" to emptyMap<String, Any?>(),
+            "schema" to emptyMap<String, Any?>(),
+            "space" to emptyMap<String, Any?>(),
+            "threat" to mapOf<String, Any?>(
+                "enrichments" to mapOf<String, Any?>(
+                    "indicator" to mapOf<String, Any?>(
+                        "as" to mapOf<String, Any?>(
+                            "organization" to emptyMap<String, Any?>()
+                        ),
+                        "email" to emptyMap<String, Any?>(),
+                        "feed" to emptyMap<String, Any?>(),
+                        "file" to mapOf<String, Any?>(
+                            "code_signature" to emptyMap<String, Any?>(),
+                            "elf" to mapOf<String, Any?>(
+                                "header" to emptyMap<String, Any?>(),
+                                "sections" to emptyMap<String, Any?>(),
+                                "segments" to emptyMap<String, Any?>()
+                            ),
+                            "hash" to emptyMap<String, Any?>(),
+                            "pe" to mapOf<String, Any?>(
+                                "sections" to emptyMap<String, Any?>()
+                            ),
+                            "x509" to mapOf<String, Any?>(
+                                "issuer" to emptyMap<String, Any?>(),
+                                "subject" to emptyMap<String, Any?>()
+                            )
+                        ),
+                        "geo" to emptyMap<String, Any?>(),
+                        "marking" to emptyMap<String, Any?>(),
+                        "registry" to mapOf<String, Any?>(
+                            "data" to emptyMap<String, Any?>()
+                        ),
+                        "software" to emptyMap<String, Any?>(),
+                        "x509" to mapOf<String, Any?>(
+                            "issuer" to emptyMap<String, Any?>(),
+                            "subject" to emptyMap<String, Any?>()
+                        )
+                    ),
+                    "matched" to emptyMap<String, Any?>()
+                ),
+                "feed" to emptyMap<String, Any?>(),
+                "group" to emptyMap<String, Any?>(),
+                "indicator" to mapOf<String, Any?>(
+                    "as" to mapOf<String, Any?>(
+                        "organization" to emptyMap<String, Any?>()
+                    ),
+                    "email" to emptyMap<String, Any?>(),
+                    "file" to mapOf<String, Any?>(
+                        "code_signature" to emptyMap<String, Any?>(),
+                        "elf" to mapOf<String, Any?>(
+                            "header" to emptyMap<String, Any?>(),
+                            "sections" to emptyMap<String, Any?>(),
+                            "segments" to emptyMap<String, Any?>()
+                        ),
+                        "hash" to emptyMap<String, Any?>(),
+                        "pe" to mapOf<String, Any?>(
+                            "sections" to emptyMap<String, Any?>()
+                        ),
+                        "x509" to mapOf<String, Any?>(
+                            "issuer" to emptyMap<String, Any?>(),
+                            "subject" to emptyMap<String, Any?>()
+                        )
+                    ),
+                    "geo" to emptyMap<String, Any?>(),
+                    "marking" to emptyMap<String, Any?>(),
+                    "registry" to mapOf<String, Any?>(
+                        "data" to emptyMap<String, Any?>()
+                    ),
+                    "x509" to mapOf<String, Any?>(
+                        "issuer" to emptyMap<String, Any?>(),
+                        "subject" to emptyMap<String, Any?>()
+                    )
+                ),
+                "software" to emptyMap<String, Any?>(),
+                "tactic" to emptyMap<String, Any?>(),
+                "technique" to mapOf<String, Any?>("subtechnique" to emptyMap<String, Any?>())
+            )
+        )
+
+        val sourceDocument = mapOf(
+            "wazuh" to wazuhObject
+        )
+
+        val getResponse = mockk<GetResponse>()
+        every { getResponse.isExists } returns true
+        every { getResponse.sourceAsMap } returns sourceDocument
+
+        val actionFuture = mockk<ActionFuture<GetResponse>>()
+        every { actionFuture.actionGet() } returns getResponse
+
+        val mockedClient = mockk<SecureIndexClient>()
+        every { mockedClient.get(any()) } returns actionFuture
+
+        val indexRequestSlot = slot<IndexRequest>()
+        val mockedBulkProcessor = mockk<BulkProcessor>()
+        val mockedBulkIndexer = mockk<ActiveResponseBulkIndexer>()
+        every { mockedBulkIndexer.add(capture(indexRequestSlot)) } returns mockedBulkProcessor
+
+        setPrivateField("client", mockedClient)
+        setPrivateField("activeResponseBulkIndexer", mockedBulkIndexer)
+
+        val activeResponse = mockk<ActiveResponse>(relaxed = true)
+        val eventStatus = EventStatus(
+            "config-id",
+            "config-name",
+            ConfigType.ACTIVE_RESPONSE,
+            listOf(),
+            DeliveryStatus("Scheduled", "Pending execution")
+        )
+
+        val response = sendActiveResponseMessage.invoke(
+            SendMessageActionHelper,
+            activeResponse,
+            "active-response-channel",
+            MessageContent("title", "doc-1|wazuh-alerts-1"),
+            eventStatus,
+            "reference-1"
+        ) as EventStatus
+
+        assertEquals(RestStatus.OK.status.toString(), response.deliveryStatus?.statusCode)
+        assertTrue(indexRequestSlot.isCaptured)
+
+        val indexedSource = indexRequestSlot.captured.source().utf8ToString()
+        assertTrue(indexedSource.contains("\"file\""), "expected wazuh.file to be preserved")
+        assertTrue(indexedSource.contains("\"agent\""), "expected wazuh.agent to be preserved")
+        assertTrue(indexedSource.contains("\"threat\""), "expected wazuh.threat to be preserved")
+        assertTrue(indexedSource.contains("\"technique\""), "expected wazuh.technique to be preserved")
+        assertTrue(indexedSource.contains("\"active_response\""), "expected active_response block to be present")
+        assertTrue(indexedSource.contains("\"doc_id\":\"doc-1\""))
     }
 
     @Test
@@ -273,6 +441,30 @@ internal class PluginActionTests {
 
         override fun onFailure(error: Exception?) {
             fail("Unexpected error happened", error)
+        }
+    }
+
+    companion object {
+        private lateinit var sendActiveResponseMessage: Method
+
+        @JvmStatic
+        @org.junit.jupiter.api.BeforeAll
+        fun initializeReflection() {
+            sendActiveResponseMessage = SendMessageActionHelper::class.java.getDeclaredMethod(
+                "sendActiveResponseMessage",
+                ActiveResponse::class.java,
+                String::class.java,
+                MessageContent::class.java,
+                EventStatus::class.java,
+                String::class.java
+            )
+            sendActiveResponseMessage.isAccessible = true
+        }
+
+        private fun setPrivateField(fieldName: String, value: Any) {
+            val field: Field = SendMessageActionHelper::class.java.getDeclaredField(fieldName)
+            field.isAccessible = true
+            field.set(SendMessageActionHelper, value)
         }
     }
 }


### PR DESCRIPTION
### Description
This PR allows copying the complete wazuh object from the original event to the active response event.

### Related Issues
Resolves #101 


### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
