### PR TITLE
Correct PLUGIN_NAME to match directory name

### DIFF
--- a/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCorePlugin.kt
+++ b/notifications/core/src/main/kotlin/org/opensearch/notifications/core/NotificationCorePlugin.kt
@@ -38,7 +38,7 @@ class NotificationCorePlugin : ReloadablePlugin, Plugin(), ExtensiblePlugin {
     internal companion object {
         private val log by logger(NotificationCorePlugin::class.java)
 
-        const val PLUGIN_NAME = "opensearch-notifications-core"
+        const val PLUGIN_NAME = "wazuh-indexer-notifications-core"
         const val LOG_PREFIX = "notifications-core"
     }
 


### PR DESCRIPTION
### Description
The `PLUGIN_NAME` constant was set to `opensearch-notifications-core` , but the plugin is installed under `wazuh-indexer-notifications-core`. This caused a `[WARN]` on every startup as the plugin tried to load its config from the wrong path.

### Related Issues
Resolves wazuh/wazuh-indexer#1578