### PR TITLE
Fix SLF4J provider: replace 1.x bridge with 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Fixed CodeQL compilation ([#15](https://github.com/wazuh/wazuh-indexer-notifications/pull/15))
 - Fixed CodeQL common-utils dependency ([#35](https://github.com/wazuh/wazuh-indexer-notifications/pull/35))
+- Fix SLF4J startup warning by replacing 1.x bridge with correct 2.x provider [(#110)](https://github.com/wazuh/wazuh-indexer-notifications/pull/110)
 
 ### Security
 -

--- a/notifications/core/build.gradle
+++ b/notifications/core/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
     implementation "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
     implementation "org.slf4j:slf4j-api:${versions.slf4j}" //Needed for httpclient5
-    implementation "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+    implementation "org.apache.logging.log4j:log4j-slf4j2-impl:${versions.log4j}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
     implementation "com.amazonaws:aws-java-sdk-core:${aws_version}"


### PR DESCRIPTION
### Description
The notifications-core plugin used `log4j-slf4j-impl` (SLF4J 1.x bridge) alongside `slf4j-api` 2.x, which is incompatible. Replaces it with `log4j-slf4j2-impl`, the correct provider for SLF4J 2.x.

### Issues Resolved
Resolves wazuh/wazuh-indexer#1577
