### PR TITLE
Limit for the Number of Notification Channels, Senders, Groups and Active Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add revert bump functionality to repository bumper workflow [(#58)](https://github.com/wazuh/wazuh-indexer-notifications/pull/58)
 - Create default notification channels on startup [(#68)](https://github.com/wazuh/wazuh-indexer-notifications/pull/68)
 - Active Response events completeness [(#105)](https://github.com/wazuh/wazuh-indexer-notifications/pull/105)
+- Add limit for the number of notification channels [(#118)](https://github.com/wazuh/wazuh-indexer-notifications/pull/118)
 
 ### Dependencies
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add revert bump functionality to repository bumper workflow [(#58)](https://github.com/wazuh/wazuh-indexer-notifications/pull/58)
 - Create default notification channels on startup [(#68)](https://github.com/wazuh/wazuh-indexer-notifications/pull/68)
 - Active Response events completeness [(#105)](https://github.com/wazuh/wazuh-indexer-notifications/pull/105)
-- Add limit for the number of notification channels [(#118)](https://github.com/wazuh/wazuh-indexer-notifications/pull/118)
+- Add limit for the number of notification channels, notification groups, notification senders, and active responses [(#118)](https://github.com/wazuh/wazuh-indexer-notifications/pull/118)
 
 ### Dependencies
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#changelog) for instructions on how to add changelog entries.
 
-## [Unreleased 5.0.x]
+## [v5.0.0]
 ### Added
 - Initialize repository. [(#2)](https://github.com/wazuh/wazuh-indexer-notifications/issues/2)
 - Implement wazuh-indexer-common-utils usage [(#17)](https://github.com/wazuh/wazuh-indexer-notifications/pull/17)
@@ -33,5 +33,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Security
 -
+
+## Prior versions
+- []()
 
 [Unreleased 5.0.x]: https://github.com/wazuh/wazuh-indexer-notifications/compare/1929b1cf1d6b05d830b58916a8d1d6182f2f5ad8...main

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -32,6 +32,7 @@ import org.opensearch.notifications.action.PublishNotificationAction
 import org.opensearch.notifications.action.SendNotificationAction
 import org.opensearch.notifications.action.SendTestNotificationAction
 import org.opensearch.notifications.action.UpdateNotificationConfigAction
+import org.opensearch.notifications.index.ConfigCreationLockService
 import org.opensearch.notifications.index.ConfigIndexingActions
 import org.opensearch.notifications.index.DefaultChannelInitializer
 import org.opensearch.notifications.index.NotificationConfigIndex
@@ -104,6 +105,10 @@ class NotificationPlugin : ActionPlugin, ClusterPlugin, Plugin(), NotificationCo
             SystemIndexDescriptor(
                 NotificationConfigIndex.INDEX_NAME,
                 "System index for storing notification channels related configurations."
+            ),
+            SystemIndexDescriptor(
+                ConfigCreationLockService.INDEX_NAME,
+                "System index for serializing the notification-config-creation limit check."
             )
         )
     }
@@ -141,6 +146,7 @@ class NotificationPlugin : ActionPlugin, ClusterPlugin, Plugin(), NotificationCo
         )
         PluginSettings.addSettingsUpdateConsumer(clusterService)
         NotificationConfigIndex.initialize(sdkClient, client, clusterService)
+        ConfigCreationLockService.initialize(client, clusterService)
         ConfigIndexingActions.initialize(NotificationConfigIndex, UserAccessManager)
         activeResponseBulkIndexer = ActiveResponseBulkIndexer(
             client,

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigCreationLockService.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigCreationLockService.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2026, Wazuh Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.opensearch.notifications.index
+
+import kotlinx.coroutines.delay
+import org.opensearch.ResourceAlreadyExistsException
+import org.opensearch.action.admin.indices.create.CreateIndexRequest
+import org.opensearch.action.admin.indices.create.CreateIndexResponse
+import org.opensearch.action.delete.DeleteRequest
+import org.opensearch.action.delete.DeleteResponse
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.get.GetResponse
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.index.IndexResponse
+import org.opensearch.action.support.WriteRequest
+import org.opensearch.cluster.service.ClusterService
+import org.opensearch.common.xcontent.XContentHelper
+import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.utils.logger
+import org.opensearch.index.engine.VersionConflictEngineException
+import org.opensearch.notifications.NotificationPlugin.Companion.LOG_PREFIX
+import org.opensearch.notifications.settings.PluginSettings
+import org.opensearch.notifications.util.SecureIndexClient
+import org.opensearch.notifications.util.SuspendUtils.Companion.suspendUntilTimeout
+import org.opensearch.transport.client.Client
+import java.time.Instant
+
+/**
+ * Serializes the notification-config-creation limit check-then-act sequence (count existing
+ * configs, then create if under the configured max) with a single short-lived mutex document.
+ *
+ * A single global lock is used -- rather than one per config type -- because
+ * [PluginSettings.maxNotificationConfigs] is a total cap spanning every config type, so any two
+ * concurrent creates (regardless of type) must be serialized to keep that count consistent. The
+ * type-specific limits (groups, senders, active responses) are checked while the same lock is
+ * held, so they are covered for free.
+ *
+ * The mutex is a document with a fixed ID, created via [IndexRequest.create] so only one caller
+ * can hold it at a time -- the same atomic-guard technique used by [DefaultChannelInitializer] to
+ * create default channels idempotently. The resource counts themselves remain live search
+ * queries; the lock only prevents two requests from evaluating those counts concurrently with a
+ * create.
+ */
+internal object ConfigCreationLockService {
+    private val log by logger(ConfigCreationLockService::class.java)
+
+    const val INDEX_NAME = ".opensearch-notifications-config-locks"
+    private const val MAPPING_FILE_NAME = "notifications-config-locks-mapping.yml"
+    private const val SETTINGS_FILE_NAME = "notifications-config-locks-settings.yml"
+    private const val LOCK_ID = "notification-config-creation"
+    private const val ACQUIRED_AT_FIELD = "acquired_at"
+    private const val MAX_ACQUIRE_RETRIES = 20
+    private const val ACQUIRE_RETRY_BACKOFF_MS = 100L
+    private const val STALE_THRESHOLD_MS = 30_000L
+
+    private lateinit var client: Client
+    private lateinit var clusterService: ClusterService
+
+    /**
+     * Initializes the service with the client and cluster service used for lock-index operations.
+     */
+    fun initialize(client: Client, clusterService: ClusterService) {
+        ConfigCreationLockService.client = SecureIndexClient(client)
+        ConfigCreationLockService.clusterService = clusterService
+    }
+
+    /**
+     * Acquires the global notification-config-creation mutex, blocking (with bounded retries)
+     * until it becomes available.
+     *
+     * @throws IllegalStateException if the lock could not be acquired after [MAX_ACQUIRE_RETRIES] attempts.
+     */
+    suspend fun acquire() {
+        ensureIndexExists()
+        for (attempt in 1..MAX_ACQUIRE_RETRIES) {
+            try {
+                val request = IndexRequest(INDEX_NAME)
+                    .id(LOCK_ID)
+                    .source(mapOf(ACQUIRED_AT_FIELD to Instant.now().toEpochMilli()))
+                    .create(true)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                val response: IndexResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+                    index(request, it)
+                }
+                log.debug("$LOG_PREFIX:Acquired notification-config-creation lock: $response")
+                return
+            } catch (e: VersionConflictEngineException) {
+                if (stealIfStale()) {
+                    continue
+                }
+                delay(ACQUIRE_RETRY_BACKOFF_MS)
+            }
+        }
+        throw IllegalStateException("$LOG_PREFIX:Timed out waiting for the notification-config-creation lock.")
+    }
+
+    /**
+     * Releases the lock. Failures are logged and swallowed so a release problem never surfaces as
+     * a config-creation failure; a lock older than [STALE_THRESHOLD_MS] is stolen by the next
+     * caller regardless.
+     */
+    suspend fun release() {
+        try {
+            val request = DeleteRequest(INDEX_NAME, LOCK_ID)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            val response: DeleteResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+                delete(request, it)
+            }
+            log.debug("$LOG_PREFIX:Released notification-config-creation lock: $response")
+        } catch (e: Exception) {
+            log.warn("$LOG_PREFIX:Failed to release notification-config-creation lock: ${e.message}")
+        }
+    }
+
+    /**
+     * Deletes the lock document if it was acquired more than [STALE_THRESHOLD_MS] ago, guarding
+     * against a lock orphaned by a crashed node.
+     *
+     * @return true if the caller should retry immediately (the lock was stolen, or had already been released).
+     */
+    private suspend fun stealIfStale(): Boolean {
+        return try {
+            val response: GetResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+                get(GetRequest(INDEX_NAME, LOCK_ID), it)
+            }
+            if (!response.isExists) {
+                // Released concurrently between our failed acquire and this check; retry immediately.
+                return true
+            }
+            val acquiredAt = (response.sourceAsMap?.get(ACQUIRED_AT_FIELD) as? Number)?.toLong() ?: 0L
+            if (Instant.now().toEpochMilli() - acquiredAt <= STALE_THRESHOLD_MS) {
+                return false
+            }
+            log.warn("$LOG_PREFIX:Stealing stale notification-config-creation lock.")
+            val deleteRequest = DeleteRequest(INDEX_NAME, LOCK_ID)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+            val deleteResponse: DeleteResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+                delete(deleteRequest, it)
+            }
+            log.debug("$LOG_PREFIX:Stole stale notification-config-creation lock: $deleteResponse")
+            true
+        } catch (e: Exception) {
+            log.warn("$LOG_PREFIX:Failed to check staleness of notification-config-creation lock: ${e.message}")
+            false
+        }
+    }
+
+    private fun isIndexExists(): Boolean {
+        return clusterService.state().routingTable.hasIndex(INDEX_NAME)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun ensureIndexExists() {
+        if (isIndexExists()) {
+            return
+        }
+        val classLoader = ConfigCreationLockService::class.java.classLoader
+        val mapping = XContentHelper.convertToMap(
+            XContentType.YAML.xContent(),
+            classLoader.getResource(MAPPING_FILE_NAME)?.readText()!!,
+            false
+        )
+        val indexSettingsSource = classLoader.getResource(SETTINGS_FILE_NAME)?.readText()!!
+        val request = CreateIndexRequest(INDEX_NAME)
+            .mapping(mapping)
+            .settings(indexSettingsSource, XContentType.YAML)
+        val storedContext = client.threadPool().threadContext.stashContext()
+        try {
+            val response: CreateIndexResponse = client.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+                admin().indices().create(request, it)
+            }
+            if (!response.isAcknowledged) {
+                log.warn("$LOG_PREFIX:Index $INDEX_NAME creation not Acknowledged")
+            }
+        } catch (exception: Exception) {
+            if (exception !is ResourceAlreadyExistsException && exception.cause !is ResourceAlreadyExistsException) {
+                throw exception
+            }
+        } finally {
+            storedContext.close()
+        }
+    }
+}

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -39,6 +39,7 @@ import org.opensearch.notifications.metrics.Metrics
 import org.opensearch.notifications.model.DocMetadata
 import org.opensearch.notifications.model.NotificationConfigDoc
 import org.opensearch.notifications.security.UserAccess
+import org.opensearch.notifications.settings.PluginSettings
 import java.time.Instant
 /**
  * NotificationConfig indexing operation actions.
@@ -226,6 +227,18 @@ object ConfigIndexingActions {
         log.info("$LOG_PREFIX:NotificationConfig-create")
         userAccess.validateUser(user)
         validateConfig(request.notificationConfig, user)
+        val count = try {
+            NotificationConfigIndex.countNotificationConfigs()
+        } catch (e: Exception) {
+            log.warn("$LOG_PREFIX:Failed to count notification configs for limit check: ${e.message}")
+            -1L
+        }
+        if (count >= 0 && count >= PluginSettings.maxNotificationConfigs) {
+            throw OpenSearchStatusException(
+                "This request would exceed the maximum allowed notification configs [${PluginSettings.maxNotificationConfigs}].",
+                RestStatus.BAD_REQUEST
+            )
+        }
         val currentTime = Instant.now()
         val metadata = DocMetadata(
             currentTime,

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -239,6 +239,54 @@ object ConfigIndexingActions {
                 RestStatus.BAD_REQUEST
             )
         }
+        when (request.notificationConfig.configType) {
+            ConfigType.EMAIL_GROUP -> {
+                val groupCount = try {
+                    NotificationConfigIndex.countNotificationConfigsByType(ConfigType.EMAIL_GROUP.tag)
+                } catch (e: Exception) {
+                    log.warn("$LOG_PREFIX:Failed to count notification groups for limit check: ${e.message}")
+                    -1L
+                }
+                if (groupCount >= 0 && groupCount >= PluginSettings.maxNotificationGroups) {
+                    throw OpenSearchStatusException(
+                        "This request would exceed the maximum allowed notification groups [${PluginSettings.maxNotificationGroups}].",
+                        RestStatus.BAD_REQUEST
+                    )
+                }
+            }
+            ConfigType.SMTP_ACCOUNT, ConfigType.SES_ACCOUNT -> {
+                val senderCount = try {
+                    NotificationConfigIndex.countNotificationConfigsByType(
+                        ConfigType.SMTP_ACCOUNT.tag,
+                        ConfigType.SES_ACCOUNT.tag
+                    )
+                } catch (e: Exception) {
+                    log.warn("$LOG_PREFIX:Failed to count notification senders for limit check: ${e.message}")
+                    -1L
+                }
+                if (senderCount >= 0 && senderCount >= PluginSettings.maxNotificationSenders) {
+                    throw OpenSearchStatusException(
+                        "This request would exceed the maximum allowed notification senders [${PluginSettings.maxNotificationSenders}].",
+                        RestStatus.BAD_REQUEST
+                    )
+                }
+            }
+            ConfigType.ACTIVE_RESPONSE -> {
+                val activeResponseCount = try {
+                    NotificationConfigIndex.countNotificationConfigsByType(ConfigType.ACTIVE_RESPONSE.tag)
+                } catch (e: Exception) {
+                    log.warn("$LOG_PREFIX:Failed to count active responses for limit check: ${e.message}")
+                    -1L
+                }
+                if (activeResponseCount >= 0 && activeResponseCount >= PluginSettings.maxActiveResponses) {
+                    throw OpenSearchStatusException(
+                        "This request would exceed the maximum allowed active responses [${PluginSettings.maxActiveResponses}].",
+                        RestStatus.BAD_REQUEST
+                    )
+                }
+            }
+            else -> {}
+        }
         val currentTime = Instant.now()
         val metadata = DocMetadata(
             currentTime,

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/ConfigIndexingActions.kt
@@ -227,82 +227,99 @@ object ConfigIndexingActions {
         log.info("$LOG_PREFIX:NotificationConfig-create")
         userAccess.validateUser(user)
         validateConfig(request.notificationConfig, user)
-        val count = try {
-            NotificationConfigIndex.countNotificationConfigs()
-        } catch (e: Exception) {
-            log.warn("$LOG_PREFIX:Failed to count notification configs for limit check: ${e.message}")
-            -1L
-        }
-        if (count >= 0 && count >= PluginSettings.maxNotificationConfigs) {
+
+        // Serialize the limit-check-then-create sequence so concurrent requests cannot all
+        // observe a stale count and overshoot the configured max. A single lock covers every
+        // config type because maxNotificationConfigs is a global cap spanning all of them.
+        try {
+            ConfigCreationLockService.acquire()
+        } catch (e: IllegalStateException) {
+            log.warn("$LOG_PREFIX:${e.message}")
             throw OpenSearchStatusException(
-                "This request would exceed the maximum allowed notification configs [${PluginSettings.maxNotificationConfigs}].",
-                RestStatus.BAD_REQUEST
+                "Too many concurrent notification config creation requests, please retry.",
+                RestStatus.TOO_MANY_REQUESTS
             )
         }
-        when (request.notificationConfig.configType) {
-            ConfigType.EMAIL_GROUP -> {
-                val groupCount = try {
-                    NotificationConfigIndex.countNotificationConfigsByType(ConfigType.EMAIL_GROUP.tag)
-                } catch (e: Exception) {
-                    log.warn("$LOG_PREFIX:Failed to count notification groups for limit check: ${e.message}")
-                    -1L
-                }
-                if (groupCount >= 0 && groupCount >= PluginSettings.maxNotificationGroups) {
-                    throw OpenSearchStatusException(
-                        "This request would exceed the maximum allowed notification groups [${PluginSettings.maxNotificationGroups}].",
-                        RestStatus.BAD_REQUEST
-                    )
-                }
+        try {
+            val count = try {
+                NotificationConfigIndex.countNotificationConfigs()
+            } catch (e: Exception) {
+                log.warn("$LOG_PREFIX:Failed to count notification configs for limit check: ${e.message}")
+                -1L
             }
-            ConfigType.SMTP_ACCOUNT, ConfigType.SES_ACCOUNT -> {
-                val senderCount = try {
-                    NotificationConfigIndex.countNotificationConfigsByType(
-                        ConfigType.SMTP_ACCOUNT.tag,
-                        ConfigType.SES_ACCOUNT.tag
-                    )
-                } catch (e: Exception) {
-                    log.warn("$LOG_PREFIX:Failed to count notification senders for limit check: ${e.message}")
-                    -1L
-                }
-                if (senderCount >= 0 && senderCount >= PluginSettings.maxNotificationSenders) {
-                    throw OpenSearchStatusException(
-                        "This request would exceed the maximum allowed notification senders [${PluginSettings.maxNotificationSenders}].",
-                        RestStatus.BAD_REQUEST
-                    )
-                }
+            if (count >= 0 && count >= PluginSettings.maxNotificationConfigs) {
+                throw OpenSearchStatusException(
+                    "This request would exceed the maximum allowed notification configs [${PluginSettings.maxNotificationConfigs}].",
+                    RestStatus.BAD_REQUEST
+                )
             }
-            ConfigType.ACTIVE_RESPONSE -> {
-                val activeResponseCount = try {
-                    NotificationConfigIndex.countNotificationConfigsByType(ConfigType.ACTIVE_RESPONSE.tag)
-                } catch (e: Exception) {
-                    log.warn("$LOG_PREFIX:Failed to count active responses for limit check: ${e.message}")
-                    -1L
+            when (request.notificationConfig.configType) {
+                ConfigType.EMAIL_GROUP -> {
+                    val groupCount = try {
+                        NotificationConfigIndex.countNotificationConfigsByType(ConfigType.EMAIL_GROUP.tag)
+                    } catch (e: Exception) {
+                        log.warn("$LOG_PREFIX:Failed to count notification groups for limit check: ${e.message}")
+                        -1L
+                    }
+                    if (groupCount >= 0 && groupCount >= PluginSettings.maxNotificationGroups) {
+                        throw OpenSearchStatusException(
+                            "This request would exceed the maximum allowed notification groups [${PluginSettings.maxNotificationGroups}].",
+                            RestStatus.BAD_REQUEST
+                        )
+                    }
                 }
-                if (activeResponseCount >= 0 && activeResponseCount >= PluginSettings.maxActiveResponses) {
-                    throw OpenSearchStatusException(
-                        "This request would exceed the maximum allowed active responses [${PluginSettings.maxActiveResponses}].",
-                        RestStatus.BAD_REQUEST
-                    )
+                ConfigType.SMTP_ACCOUNT, ConfigType.SES_ACCOUNT -> {
+                    val senderCount = try {
+                        NotificationConfigIndex.countNotificationConfigsByType(
+                            ConfigType.SMTP_ACCOUNT.tag,
+                            ConfigType.SES_ACCOUNT.tag
+                        )
+                    } catch (e: Exception) {
+                        log.warn("$LOG_PREFIX:Failed to count notification senders for limit check: ${e.message}")
+                        -1L
+                    }
+                    if (senderCount >= 0 && senderCount >= PluginSettings.maxNotificationSenders) {
+                        throw OpenSearchStatusException(
+                            "This request would exceed the maximum allowed notification senders [${PluginSettings.maxNotificationSenders}].",
+                            RestStatus.BAD_REQUEST
+                        )
+                    }
                 }
+                ConfigType.ACTIVE_RESPONSE -> {
+                    val activeResponseCount = try {
+                        NotificationConfigIndex.countNotificationConfigsByType(ConfigType.ACTIVE_RESPONSE.tag)
+                    } catch (e: Exception) {
+                        log.warn("$LOG_PREFIX:Failed to count active responses for limit check: ${e.message}")
+                        -1L
+                    }
+                    if (activeResponseCount >= 0 && activeResponseCount >= PluginSettings.maxActiveResponses) {
+                        throw OpenSearchStatusException(
+                            "This request would exceed the maximum allowed active responses [${PluginSettings.maxActiveResponses}].",
+                            RestStatus.BAD_REQUEST
+                        )
+                    }
+                }
+                else -> {}
             }
-            else -> {}
-        }
-        val currentTime = Instant.now()
-        val metadata = DocMetadata(
-            currentTime,
-            currentTime,
-            userAccess.getAllAccessInfo(user)
-        )
-        val configDoc = NotificationConfigDoc(metadata, request.notificationConfig)
-        val docId = operations.createNotificationConfig(configDoc, request.configId)
-        docId ?: run {
-            Metrics.NOTIFICATIONS_CONFIG_CREATE_SYSTEM_ERROR.counter.increment()
-            throw OpenSearchStatusException(
-                "NotificationConfig Creation failed",
-                RestStatus.INTERNAL_SERVER_ERROR
+            val currentTime = Instant.now()
+            val metadata = DocMetadata(
+                currentTime,
+                currentTime,
+                userAccess.getAllAccessInfo(user)
             )
+            val configDoc = NotificationConfigDoc(metadata, request.notificationConfig)
+            val docId = operations.createNotificationConfig(configDoc, request.configId)
+            docId ?: run {
+                Metrics.NOTIFICATIONS_CONFIG_CREATE_SYSTEM_ERROR.counter.increment()
+                throw OpenSearchStatusException(
+                    "NotificationConfig Creation failed",
+                    RestStatus.INTERNAL_SERVER_ERROR
+                )
+            }
+            return CreateNotificationConfigResponse(docId)
+        } finally {
+            ConfigCreationLockService.release()
         }
-        return CreateNotificationConfigResponse(docId)
     }
 
     /**

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -24,6 +24,8 @@ import org.opensearch.common.util.concurrent.ThreadContext
 import org.opensearch.common.xcontent.LoggingDeprecationHandler
 import org.opensearch.common.xcontent.XContentHelper
 import org.opensearch.common.xcontent.XContentType
+import org.opensearch.commons.notifications.NotificationConstants.CONFIG_TAG
+import org.opensearch.commons.notifications.NotificationConstants.CONFIG_TYPE_TAG
 import org.opensearch.commons.notifications.action.GetNotificationConfigRequest
 import org.opensearch.commons.notifications.model.NotificationConfigInfo
 import org.opensearch.commons.notifications.model.NotificationConfigSearchResult
@@ -193,6 +195,32 @@ internal object NotificationConfigIndex : ConfigOperations {
             .timeout(TimeValue(PluginSettings.operationTimeoutMs, TimeUnit.MILLISECONDS))
             .size(0)
             .trackTotalHits(true)
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(INDEX_NAME)
+            .searchSourceBuilder(sourceBuilder)
+            .build()
+        val response: SearchResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            sdkClient.searchDataObjectAsync(searchRequest).whenComplete(it)
+        }
+        return response.hits.totalHits?.value ?: 0L
+    }
+
+    /**
+     * Count notification config documents of specific types.
+     * Returns 0 if the index does not exist yet.
+     * @param configTypes one or more config type tags to filter by (e.g. "email_group", "smtp_account")
+     * @return total number of matching notification configs
+     */
+    suspend fun countNotificationConfigsByType(vararg configTypes: String): Long {
+        if (!isIndexExists()) {
+            return 0L
+        }
+        val query = QueryBuilders.termsQuery("$CONFIG_TAG.$CONFIG_TYPE_TAG", configTypes.toList())
+        val sourceBuilder = SearchSourceBuilder()
+            .timeout(TimeValue(PluginSettings.operationTimeoutMs, TimeUnit.MILLISECONDS))
+            .size(0)
+            .trackTotalHits(true)
+            .query(query)
         val searchRequest = SearchDataObjectRequest.builder()
             .indices(INDEX_NAME)
             .searchSourceBuilder(sourceBuilder)

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -181,6 +181,29 @@ internal object NotificationConfigIndex : ConfigOperations {
     }
 
     /**
+     * Count all notification config documents in the index.
+     * Returns 0 if the index does not exist yet.
+     * @return total number of notification configs
+     */
+    suspend fun countNotificationConfigs(): Long {
+        if (!isIndexExists()) {
+            return 0L
+        }
+        val sourceBuilder = SearchSourceBuilder()
+            .timeout(TimeValue(PluginSettings.operationTimeoutMs, TimeUnit.MILLISECONDS))
+            .size(0)
+            .trackTotalHits(true)
+        val searchRequest = SearchDataObjectRequest.builder()
+            .indices(INDEX_NAME)
+            .searchSourceBuilder(sourceBuilder)
+            .build()
+        val response: SearchResponse = sdkClient.suspendUntilTimeout(PluginSettings.operationTimeoutMs) {
+            sdkClient.searchDataObjectAsync(searchRequest).whenComplete(it)
+        }
+        return response.hits.totalHits?.value ?: 0L
+    }
+
+    /**
      * {@inheritDoc}
      */
     override suspend fun createNotificationConfig(configDoc: NotificationConfigDoc, id: String?): String? {

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/index/NotificationConfigIndex.kt
@@ -17,6 +17,7 @@ import org.opensearch.action.get.MultiGetRequest
 import org.opensearch.action.get.MultiGetResponse
 import org.opensearch.action.index.IndexResponse
 import org.opensearch.action.search.SearchResponse
+import org.opensearch.action.support.WriteRequest
 import org.opensearch.action.support.clustermanager.AcknowledgedResponse
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.unit.TimeValue
@@ -240,6 +241,10 @@ internal object NotificationConfigIndex : ConfigOperations {
             .index(INDEX_NAME)
             .dataObject({ builder, params -> configDoc.toXContent(builder, params) })
             .overwriteIfExists(false)
+            // The limit-check count queries run while ConfigCreationLockService's mutex is held; an
+            // immediate refresh here guarantees the next lock holder's count sees this document,
+            // closing the window that made the check-then-act race possible.
+            .refreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
         if (id != null) {
             postRequest.id(id)
         }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -71,6 +71,21 @@ internal object PluginSettings {
     private const val MAX_NOTIFICATION_CONFIGS_KEY = "$GENERAL_KEY_PREFIX.max_notification_configs"
 
     /**
+     * Maximum number of notification groups (email groups) allowed.
+     */
+    private const val MAX_NOTIFICATION_GROUPS_KEY = "plugins.notifications.general.max_notification_groups"
+
+    /**
+     * Maximum number of notification senders (SMTP/SES accounts) allowed.
+     */
+    private const val MAX_NOTIFICATION_SENDERS_KEY = "plugins.notifications.general.max_notification_senders"
+
+    /**
+     * Maximum number of active response configurations allowed.
+     */
+    private const val MAX_ACTIVE_RESPONSES_KEY = "plugins.notifications.max_active_responses"
+
+    /**
      * Legacy alerting plugin filter_by_backend_roles setting.
      */
     private const val LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES_KEY = "opendistro.alerting.filter_by_backend_roles"
@@ -108,12 +123,42 @@ internal object PluginSettings {
     /**
      * Default maximum number of notification channel configurations.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = 100
+    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = 10
 
     /**
      * Minimum allowed value for the max notification configs setting.
      */
     private const val MINIMUM_MAX_NOTIFICATION_CONFIGS = 0
+
+    /**
+     * Default maximum number of notification groups.
+     */
+    private const val DEFAULT_MAX_NOTIFICATION_GROUPS_VALUE = 10
+
+    /**
+     * Minimum allowed value for the max notification groups setting.
+     */
+    private const val MINIMUM_MAX_NOTIFICATION_GROUPS = 0
+
+    /**
+     * Default maximum number of notification senders.
+     */
+    private const val DEFAULT_MAX_NOTIFICATION_SENDERS_VALUE = 5
+
+    /**
+     * Minimum allowed value for the max notification senders setting.
+     */
+    private const val MINIMUM_MAX_NOTIFICATION_SENDERS = 0
+
+    /**
+     * Default maximum number of active response configurations.
+     */
+    private const val DEFAULT_MAX_ACTIVE_RESPONSES_VALUE = 10
+
+    /**
+     * Minimum allowed value for the max active responses setting.
+     */
+    private const val MINIMUM_MAX_ACTIVE_RESPONSES = 0
 
     /**
      * Default bulk flush interval for active response (ms).
@@ -154,6 +199,24 @@ internal object PluginSettings {
     var maxNotificationConfigs: Int
 
     /**
+     * Maximum number of notification groups allowed.
+     */
+    @Volatile
+    var maxNotificationGroups: Int
+
+    /**
+     * Maximum number of notification senders allowed.
+     */
+    @Volatile
+    var maxNotificationSenders: Int
+
+    /**
+     * Maximum number of active response configurations allowed.
+     */
+    @Volatile
+    var maxActiveResponses: Int
+
+    /**
      * Bulk flush interval for active response indexing (ms).
      * Read once at plugin startup. The value is fixed for the lifetime of the node —
      * BulkProcessor does not support live reconfiguration, so this setting is NodeScope-only.
@@ -190,6 +253,12 @@ internal object PluginSettings {
             ?: DEFAULT_ITEMS_QUERY_COUNT_VALUE
         maxNotificationConfigs = (settings?.get(MAX_NOTIFICATION_CONFIGS_KEY)?.toInt())
             ?: DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE
+        maxNotificationGroups = (settings?.get(MAX_NOTIFICATION_GROUPS_KEY)?.toInt())
+            ?: DEFAULT_MAX_NOTIFICATION_GROUPS_VALUE
+        maxNotificationSenders = (settings?.get(MAX_NOTIFICATION_SENDERS_KEY)?.toInt())
+            ?: DEFAULT_MAX_NOTIFICATION_SENDERS_VALUE
+        maxActiveResponses = (settings?.get(MAX_ACTIVE_RESPONSES_KEY)?.toInt())
+            ?: DEFAULT_MAX_ACTIVE_RESPONSES_VALUE
         activeResponseBulkFlushIntervalMs = (settings?.get(ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY)?.toLong())
             ?: DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
         activeResponseBulkMaxActions = (settings?.get(ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY)?.toInt())
@@ -197,7 +266,10 @@ internal object PluginSettings {
         defaultSettings = mapOf(
             OPERATION_TIMEOUT_MS_KEY to operationTimeoutMs.toString(DECIMAL_RADIX),
             DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX),
-            MAX_NOTIFICATION_CONFIGS_KEY to maxNotificationConfigs.toString(DECIMAL_RADIX)
+            MAX_NOTIFICATION_CONFIGS_KEY to maxNotificationConfigs.toString(DECIMAL_RADIX),
+            MAX_NOTIFICATION_GROUPS_KEY to maxNotificationGroups.toString(DECIMAL_RADIX),
+            MAX_NOTIFICATION_SENDERS_KEY to maxNotificationSenders.toString(DECIMAL_RADIX),
+            MAX_ACTIVE_RESPONSES_KEY to maxActiveResponses.toString(DECIMAL_RADIX)
         )
     }
 
@@ -221,6 +293,30 @@ internal object PluginSettings {
         MAX_NOTIFICATION_CONFIGS_KEY,
         defaultSettings[MAX_NOTIFICATION_CONFIGS_KEY]!!.toInt(),
         MINIMUM_MAX_NOTIFICATION_CONFIGS,
+        NodeScope,
+        Dynamic
+    )
+
+    val MAX_NOTIFICATION_GROUPS: Setting<Int> = Setting.intSetting(
+        MAX_NOTIFICATION_GROUPS_KEY,
+        defaultSettings[MAX_NOTIFICATION_GROUPS_KEY]!!.toInt(),
+        MINIMUM_MAX_NOTIFICATION_GROUPS,
+        NodeScope,
+        Dynamic
+    )
+
+    val MAX_NOTIFICATION_SENDERS: Setting<Int> = Setting.intSetting(
+        MAX_NOTIFICATION_SENDERS_KEY,
+        defaultSettings[MAX_NOTIFICATION_SENDERS_KEY]!!.toInt(),
+        MINIMUM_MAX_NOTIFICATION_SENDERS,
+        NodeScope,
+        Dynamic
+    )
+
+    val MAX_ACTIVE_RESPONSES: Setting<Int> = Setting.intSetting(
+        MAX_ACTIVE_RESPONSES_KEY,
+        defaultSettings[MAX_ACTIVE_RESPONSES_KEY]!!.toInt(),
+        MINIMUM_MAX_ACTIVE_RESPONSES,
         NodeScope,
         Dynamic
     )
@@ -326,6 +422,9 @@ internal object PluginSettings {
             OPERATION_TIMEOUT_MS,
             DEFAULT_ITEMS_QUERY_COUNT,
             MAX_NOTIFICATION_CONFIGS,
+            MAX_NOTIFICATION_GROUPS,
+            MAX_NOTIFICATION_SENDERS,
+            MAX_ACTIVE_RESPONSES,
             ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
             ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
             FILTER_BY_BACKEND_ROLES,
@@ -345,6 +444,9 @@ internal object PluginSettings {
         operationTimeoutMs = OPERATION_TIMEOUT_MS.get(clusterService.settings)
         defaultItemsQueryCount = DEFAULT_ITEMS_QUERY_COUNT.get(clusterService.settings)
         maxNotificationConfigs = MAX_NOTIFICATION_CONFIGS.get(clusterService.settings)
+        maxNotificationGroups = MAX_NOTIFICATION_GROUPS.get(clusterService.settings)
+        maxNotificationSenders = MAX_NOTIFICATION_SENDERS.get(clusterService.settings)
+        maxActiveResponses = MAX_ACTIVE_RESPONSES.get(clusterService.settings)
         activeResponseBulkFlushIntervalMs = ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS.get(clusterService.settings)
         activeResponseBulkMaxActions = ACTIVE_RESPONSE_BULK_MAX_ACTIONS.get(clusterService.settings)
     }
@@ -369,6 +471,21 @@ internal object PluginSettings {
         if (clusterMaxNotificationConfigs != null) {
             log.debug("$LOG_PREFIX:$MAX_NOTIFICATION_CONFIGS_KEY -autoUpdatedTo-> $clusterMaxNotificationConfigs")
             maxNotificationConfigs = clusterMaxNotificationConfigs
+        }
+        val clusterMaxNotificationGroups = clusterService.clusterSettings.get(MAX_NOTIFICATION_GROUPS)
+        if (clusterMaxNotificationGroups != null) {
+            log.debug("$LOG_PREFIX:$MAX_NOTIFICATION_GROUPS_KEY -autoUpdatedTo-> $clusterMaxNotificationGroups")
+            maxNotificationGroups = clusterMaxNotificationGroups
+        }
+        val clusterMaxNotificationSenders = clusterService.clusterSettings.get(MAX_NOTIFICATION_SENDERS)
+        if (clusterMaxNotificationSenders != null) {
+            log.debug("$LOG_PREFIX:$MAX_NOTIFICATION_SENDERS_KEY -autoUpdatedTo-> $clusterMaxNotificationSenders")
+            maxNotificationSenders = clusterMaxNotificationSenders
+        }
+        val clusterMaxActiveResponses = clusterService.clusterSettings.get(MAX_ACTIVE_RESPONSES)
+        if (clusterMaxActiveResponses != null) {
+            log.debug("$LOG_PREFIX:$MAX_ACTIVE_RESPONSES_KEY -autoUpdatedTo-> $clusterMaxActiveResponses")
+            maxActiveResponses = clusterMaxActiveResponses
         }
         // ACTIVE_RESPONSE_BULK_* settings are NodeScope-only; they are read once in
         // updateSettingValuesFromLocal at startup and cannot change at runtime, so
@@ -398,6 +515,18 @@ internal object PluginSettings {
             maxNotificationConfigs = it
             log.info("$LOG_PREFIX:$MAX_NOTIFICATION_CONFIGS_KEY -updatedTo-> $it")
         }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_NOTIFICATION_GROUPS) {
+            maxNotificationGroups = it
+            log.info("$LOG_PREFIX:$MAX_NOTIFICATION_GROUPS_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_NOTIFICATION_SENDERS) {
+            maxNotificationSenders = it
+            log.info("$LOG_PREFIX:$MAX_NOTIFICATION_SENDERS_KEY -updatedTo-> $it")
+        }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_ACTIVE_RESPONSES) {
+            maxActiveResponses = it
+            log.info("$LOG_PREFIX:$MAX_ACTIVE_RESPONSES_KEY -updatedTo-> $it")
+        }
         // No update consumers for ACTIVE_RESPONSE_BULK_* — those settings are NodeScope-only
         // and cannot change at runtime (BulkProcessor has no live-reconfig API).
     }
@@ -408,6 +537,9 @@ internal object PluginSettings {
         operationTimeoutMs = DEFAULT_OPERATION_TIMEOUT_MS
         defaultItemsQueryCount = DEFAULT_ITEMS_QUERY_COUNT_VALUE
         maxNotificationConfigs = DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE
+        maxNotificationGroups = DEFAULT_MAX_NOTIFICATION_GROUPS_VALUE
+        maxNotificationSenders = DEFAULT_MAX_NOTIFICATION_SENDERS_VALUE
+        maxActiveResponses = DEFAULT_MAX_ACTIVE_RESPONSES_VALUE
         activeResponseBulkFlushIntervalMs = DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
         activeResponseBulkMaxActions = DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -68,17 +68,17 @@ internal object PluginSettings {
     /**
      * Maximum number of notification channel configurations allowed.
      */
-    private const val MAX_NOTIFICATION_CONFIGS_KEY = "plugins.notifications.general.max_notification_configs"
+    private const val MAX_NOTIFICATION_CONFIGS_KEY = "plugins.notifications.max_notification_configs"
 
     /**
      * Maximum number of notification groups (email groups) allowed.
      */
-    private const val MAX_NOTIFICATION_GROUPS_KEY = "plugins.notifications.general.max_notification_groups"
+    private const val MAX_NOTIFICATION_GROUPS_KEY = "plugins.notifications.max_notification_groups"
 
     /**
      * Maximum number of notification senders (SMTP/SES accounts) allowed.
      */
-    private const val MAX_NOTIFICATION_SENDERS_KEY = "plugins.notifications.general.max_notification_senders"
+    private const val MAX_NOTIFICATION_SENDERS_KEY = "plugins.notifications.max_notification_senders"
 
     /**
      * Maximum number of active response configurations allowed.
@@ -123,7 +123,7 @@ internal object PluginSettings {
     /**
      * Default maximum number of notification channel configurations.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = 10
+    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = 40
 
     /**
      * Minimum allowed value for the max notification configs setting.

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -68,7 +68,7 @@ internal object PluginSettings {
     /**
      * Maximum number of notification channel configurations allowed.
      */
-    private const val MAX_NOTIFICATION_CONFIGS_KEY = "$GENERAL_KEY_PREFIX.max_notification_configs"
+    private const val MAX_NOTIFICATION_CONFIGS_KEY = "plugins.notifications.general.max_notification_configs"
 
     /**
      * Maximum number of notification groups (email groups) allowed.

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -66,6 +66,11 @@ internal object PluginSettings {
     private const val DEFAULT_ITEMS_QUERY_COUNT_KEY = "$GENERAL_KEY_PREFIX.default_items_query_count"
 
     /**
+     * Maximum number of notification channel configurations allowed.
+     */
+    private const val MAX_NOTIFICATION_CONFIGS_KEY = "$GENERAL_KEY_PREFIX.max_notification_configs"
+
+    /**
      * Legacy alerting plugin filter_by_backend_roles setting.
      */
     private const val LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES_KEY = "opendistro.alerting.filter_by_backend_roles"
@@ -101,6 +106,16 @@ internal object PluginSettings {
     private const val MINIMUM_ITEMS_QUERY_COUNT = 10
 
     /**
+     * Default maximum number of notification channel configurations.
+     */
+    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = 100
+
+    /**
+     * Minimum allowed value for the max notification configs setting.
+     */
+    private const val MINIMUM_MAX_NOTIFICATION_CONFIGS = 0
+
+    /**
      * Default bulk flush interval for active response (ms).
      */
     private const val DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS = 500L
@@ -131,6 +146,12 @@ internal object PluginSettings {
      */
     @Volatile
     var defaultItemsQueryCount: Int
+
+    /**
+     * Maximum number of notification channel configurations allowed.
+     */
+    @Volatile
+    var maxNotificationConfigs: Int
 
     /**
      * Bulk flush interval for active response indexing (ms).
@@ -167,13 +188,16 @@ internal object PluginSettings {
         operationTimeoutMs = (settings?.get(OPERATION_TIMEOUT_MS_KEY)?.toLong()) ?: DEFAULT_OPERATION_TIMEOUT_MS
         defaultItemsQueryCount = (settings?.get(DEFAULT_ITEMS_QUERY_COUNT_KEY)?.toInt())
             ?: DEFAULT_ITEMS_QUERY_COUNT_VALUE
+        maxNotificationConfigs = (settings?.get(MAX_NOTIFICATION_CONFIGS_KEY)?.toInt())
+            ?: DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE
         activeResponseBulkFlushIntervalMs = (settings?.get(ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS_KEY)?.toLong())
             ?: DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
         activeResponseBulkMaxActions = (settings?.get(ACTIVE_RESPONSE_BULK_MAX_ACTIONS_KEY)?.toInt())
             ?: DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS
         defaultSettings = mapOf(
             OPERATION_TIMEOUT_MS_KEY to operationTimeoutMs.toString(DECIMAL_RADIX),
-            DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX)
+            DEFAULT_ITEMS_QUERY_COUNT_KEY to defaultItemsQueryCount.toString(DECIMAL_RADIX),
+            MAX_NOTIFICATION_CONFIGS_KEY to maxNotificationConfigs.toString(DECIMAL_RADIX)
         )
     }
 
@@ -189,6 +213,14 @@ internal object PluginSettings {
         DEFAULT_ITEMS_QUERY_COUNT_KEY,
         defaultSettings[DEFAULT_ITEMS_QUERY_COUNT_KEY]!!.toInt(),
         MINIMUM_ITEMS_QUERY_COUNT,
+        NodeScope,
+        Dynamic
+    )
+
+    val MAX_NOTIFICATION_CONFIGS: Setting<Int> = Setting.intSetting(
+        MAX_NOTIFICATION_CONFIGS_KEY,
+        defaultSettings[MAX_NOTIFICATION_CONFIGS_KEY]!!.toInt(),
+        MINIMUM_MAX_NOTIFICATION_CONFIGS,
         NodeScope,
         Dynamic
     )
@@ -293,6 +325,7 @@ internal object PluginSettings {
         return listOf(
             OPERATION_TIMEOUT_MS,
             DEFAULT_ITEMS_QUERY_COUNT,
+            MAX_NOTIFICATION_CONFIGS,
             ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
             ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
             FILTER_BY_BACKEND_ROLES,
@@ -311,6 +344,7 @@ internal object PluginSettings {
     private fun updateSettingValuesFromLocal(clusterService: ClusterService) {
         operationTimeoutMs = OPERATION_TIMEOUT_MS.get(clusterService.settings)
         defaultItemsQueryCount = DEFAULT_ITEMS_QUERY_COUNT.get(clusterService.settings)
+        maxNotificationConfigs = MAX_NOTIFICATION_CONFIGS.get(clusterService.settings)
         activeResponseBulkFlushIntervalMs = ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS.get(clusterService.settings)
         activeResponseBulkMaxActions = ACTIVE_RESPONSE_BULK_MAX_ACTIONS.get(clusterService.settings)
     }
@@ -330,6 +364,11 @@ internal object PluginSettings {
         if (clusterDefaultItemsQueryCount != null) {
             log.debug("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -autoUpdatedTo-> $clusterDefaultItemsQueryCount")
             defaultItemsQueryCount = clusterDefaultItemsQueryCount
+        }
+        val clusterMaxNotificationConfigs = clusterService.clusterSettings.get(MAX_NOTIFICATION_CONFIGS)
+        if (clusterMaxNotificationConfigs != null) {
+            log.debug("$LOG_PREFIX:$MAX_NOTIFICATION_CONFIGS_KEY -autoUpdatedTo-> $clusterMaxNotificationConfigs")
+            maxNotificationConfigs = clusterMaxNotificationConfigs
         }
         // ACTIVE_RESPONSE_BULK_* settings are NodeScope-only; they are read once in
         // updateSettingValuesFromLocal at startup and cannot change at runtime, so
@@ -355,6 +394,10 @@ internal object PluginSettings {
             defaultItemsQueryCount = it
             log.info("$LOG_PREFIX:$DEFAULT_ITEMS_QUERY_COUNT_KEY -updatedTo-> $it")
         }
+        clusterService.clusterSettings.addSettingsUpdateConsumer(MAX_NOTIFICATION_CONFIGS) {
+            maxNotificationConfigs = it
+            log.info("$LOG_PREFIX:$MAX_NOTIFICATION_CONFIGS_KEY -updatedTo-> $it")
+        }
         // No update consumers for ACTIVE_RESPONSE_BULK_* — those settings are NodeScope-only
         // and cannot change at runtime (BulkProcessor has no live-reconfig API).
     }
@@ -364,6 +407,7 @@ internal object PluginSettings {
     fun reset() {
         operationTimeoutMs = DEFAULT_OPERATION_TIMEOUT_MS
         defaultItemsQueryCount = DEFAULT_ITEMS_QUERY_COUNT_VALUE
+        maxNotificationConfigs = DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE
         activeResponseBulkFlushIntervalMs = DEFAULT_ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS
         activeResponseBulkMaxActions = DEFAULT_ACTIVE_RESPONSE_BULK_MAX_ACTIONS
     }

--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -121,9 +121,14 @@ internal object PluginSettings {
     private const val MINIMUM_ITEMS_QUERY_COUNT = 10
 
     /**
+     * Maximum allowed value for the max notification configs setting.
+     */
+    private const val MAXIMUM_MAX_NOTIFICATION_CONFIGS = 40
+
+    /**
      * Default maximum number of notification channel configurations.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = 40
+    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = MAXIMUM_MAX_NOTIFICATION_CONFIGS
 
     /**
      * Minimum allowed value for the max notification configs setting.
@@ -131,9 +136,14 @@ internal object PluginSettings {
     private const val MINIMUM_MAX_NOTIFICATION_CONFIGS = 0
 
     /**
+     * Maximum allowed value for the max notification groups setting.
+     */
+    private const val MAXIMUM_MAX_NOTIFICATION_GROUPS = 10
+
+    /**
      * Default maximum number of notification groups.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_GROUPS_VALUE = 10
+    private const val DEFAULT_MAX_NOTIFICATION_GROUPS_VALUE = MAXIMUM_MAX_NOTIFICATION_GROUPS
 
     /**
      * Minimum allowed value for the max notification groups setting.
@@ -141,9 +151,14 @@ internal object PluginSettings {
     private const val MINIMUM_MAX_NOTIFICATION_GROUPS = 0
 
     /**
+     * Maximum allowed value for the max notification senders setting.
+     */
+    private const val MAXIMUM_MAX_NOTIFICATION_SENDERS = 5
+
+    /**
      * Default maximum number of notification senders.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_SENDERS_VALUE = 5
+    private const val DEFAULT_MAX_NOTIFICATION_SENDERS_VALUE = MAXIMUM_MAX_NOTIFICATION_SENDERS
 
     /**
      * Minimum allowed value for the max notification senders setting.
@@ -151,9 +166,14 @@ internal object PluginSettings {
     private const val MINIMUM_MAX_NOTIFICATION_SENDERS = 0
 
     /**
+     * Maximum allowed value for the max active responses setting.
+     */
+    private const val MAXIMUM_MAX_ACTIVE_RESPONSES = 10
+
+    /**
      * Default maximum number of active response configurations.
      */
-    private const val DEFAULT_MAX_ACTIVE_RESPONSES_VALUE = 10
+    private const val DEFAULT_MAX_ACTIVE_RESPONSES_VALUE = MAXIMUM_MAX_ACTIVE_RESPONSES
 
     /**
      * Minimum allowed value for the max active responses setting.
@@ -293,6 +313,7 @@ internal object PluginSettings {
         MAX_NOTIFICATION_CONFIGS_KEY,
         defaultSettings[MAX_NOTIFICATION_CONFIGS_KEY]!!.toInt(),
         MINIMUM_MAX_NOTIFICATION_CONFIGS,
+        MAXIMUM_MAX_NOTIFICATION_CONFIGS,
         NodeScope,
         Dynamic
     )
@@ -301,6 +322,7 @@ internal object PluginSettings {
         MAX_NOTIFICATION_GROUPS_KEY,
         defaultSettings[MAX_NOTIFICATION_GROUPS_KEY]!!.toInt(),
         MINIMUM_MAX_NOTIFICATION_GROUPS,
+        MAXIMUM_MAX_NOTIFICATION_GROUPS,
         NodeScope,
         Dynamic
     )
@@ -309,6 +331,7 @@ internal object PluginSettings {
         MAX_NOTIFICATION_SENDERS_KEY,
         defaultSettings[MAX_NOTIFICATION_SENDERS_KEY]!!.toInt(),
         MINIMUM_MAX_NOTIFICATION_SENDERS,
+        MAXIMUM_MAX_NOTIFICATION_SENDERS,
         NodeScope,
         Dynamic
     )
@@ -317,6 +340,7 @@ internal object PluginSettings {
         MAX_ACTIVE_RESPONSES_KEY,
         defaultSettings[MAX_ACTIVE_RESPONSES_KEY]!!.toInt(),
         MINIMUM_MAX_ACTIVE_RESPONSES,
+        MAXIMUM_MAX_ACTIVE_RESPONSES,
         NodeScope,
         Dynamic
     )

--- a/notifications/notifications/src/main/resources/notifications-config-locks-mapping.yml
+++ b/notifications/notifications/src/main/resources/notifications-config-locks-mapping.yml
@@ -1,0 +1,16 @@
+---
+##
+ # Copyright (C) 2026, Wazuh Inc.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU Affero General Public License as
+ # published by the Free Software Foundation, either version 3 of the
+ # License, or (at your option) any later version.
+##
+
+# Schema file for the notifications-config-locks index
+# "dynamic" is set to "strict" so this index only ever holds the fields the lock service uses.
+dynamic: strict
+properties:
+  acquired_at:
+    type: long

--- a/notifications/notifications/src/main/resources/notifications-config-locks-settings.yml
+++ b/notifications/notifications/src/main/resources/notifications-config-locks-settings.yml
@@ -1,0 +1,16 @@
+---
+##
+ # Copyright (C) 2026, Wazuh Inc.
+ #
+ # This program is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU Affero General Public License as
+ # published by the Free Software Foundation, either version 3 of the
+ # License, or (at your option) any later version.
+##
+
+# Settings file for the notifications-config-locks index
+index:
+  number_of_shards: "1"
+  number_of_replicas: "0"
+  hidden: true
+  refresh_interval: "-1" # Lock acquire/release explicitly request an immediate refresh per write.

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/DeleteNotificationConfigIT.kt
@@ -69,20 +69,20 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
     }
 
     fun `test Delete multiple notification config`() {
-        val configIds: Set<String> = (1..20).map { createConfig() }.toSet()
+        val configIds: Set<String> = (1..5).map { createConfig() }.toSet()
         Thread.sleep(1000)
 
-        // Get all notification configs
+        // Get created notification configs by ID list (avoids counting default channels)
         val getAllConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs",
+            "$PLUGIN_BASE_URI/configs?config_id_list=${configIds.joinToString(",")}",
             "",
             RestStatus.OK.status
         )
-        verifyMultiConfigIdEquals(configIds, getAllConfigResponse)
+        verifyMultiConfigIdEquals(configIds, getAllConfigResponse, configIds.size)
         Thread.sleep(100)
 
-        // Delete notification config
+        // Delete notification configs
         val deleteResponse = deleteConfigs(configIds)
         val deletedObject = deleteResponse.get("delete_response_list").asJsonObject
         configIds.forEach {
@@ -90,36 +90,37 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         }
         Thread.sleep(1000)
 
-        // Get notification configs after delete
-        val getAfterDelete = executeRequest(
-            RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs",
-            "",
-            RestStatus.OK.status
-        )
-        Assert.assertEquals(0, getAfterDelete.get("total_hits").asInt)
+        // Verify each deleted config is gone
+        configIds.forEach { configId ->
+            executeRequest(
+                RestRequest.Method.GET.name,
+                "$PLUGIN_BASE_URI/configs/$configId",
+                "",
+                RestStatus.NOT_FOUND.status
+            )
+        }
         Thread.sleep(100)
     }
 
     fun `test Delete some items from multiple notification config with missing configs should fail`() {
-        val configIds: Set<String> = (1..19).map { createConfig() }.toSet()
+        val configIds: Set<String> = (1..5).map { createConfig() }.toSet()
         Thread.sleep(1000)
 
-        // Get all notification configs
+        // Get created notification configs by ID list (avoids counting default channels)
         val getAllConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs",
+            "$PLUGIN_BASE_URI/configs?config_id_list=${configIds.joinToString(",")}",
             "",
             RestStatus.OK.status
         )
-        verifyMultiConfigIdEquals(configIds, getAllConfigResponse)
+        verifyMultiConfigIdEquals(configIds, getAllConfigResponse, configIds.size)
         Thread.sleep(100)
 
         var index = 0
         val partitions = configIds.partition { (index++) % 2 == 0 }
         val deletedIds = partitions.first.toSet()
 
-        // Delete notification config
+        // Delete notification config (with a non-existent ID appended — should fail)
         executeRequest(
             RestRequest.Method.DELETE.name,
             "$PLUGIN_BASE_URI/configs?config_id_list=${deletedIds.joinToString(separator = ",")},extra_id",
@@ -128,29 +129,29 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         )
         Thread.sleep(1000)
 
-        // Get notification configs after failed delete
+        // Verify all original configs are still present after the failed delete
         val getAfterDelete = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs",
+            "$PLUGIN_BASE_URI/configs?config_id_list=${configIds.joinToString(",")}",
             "",
             RestStatus.OK.status
         )
-        verifyMultiConfigIdEquals(configIds, getAfterDelete)
+        verifyMultiConfigIdEquals(configIds, getAfterDelete, configIds.size)
         Thread.sleep(100)
     }
 
     fun `test Delete partial items from multiple notification config`() {
-        val configIds: Set<String> = (1..19).map { createConfig() }.toSet()
+        val configIds: Set<String> = (1..5).map { createConfig() }.toSet()
         Thread.sleep(1000)
 
-        // Get all notification configs
+        // Get created notification configs by ID list (avoids counting default channels)
         val getAllConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs",
+            "$PLUGIN_BASE_URI/configs?config_id_list=${configIds.joinToString(",")}",
             "",
             RestStatus.OK.status
         )
-        verifyMultiConfigIdEquals(configIds, getAllConfigResponse)
+        verifyMultiConfigIdEquals(configIds, getAllConfigResponse, configIds.size)
         Thread.sleep(100)
 
         var index = 0
@@ -158,7 +159,7 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         val deletedIds = partitions.first.toSet()
         val remainingIds = partitions.second.toSet()
 
-        // Delete notification config
+        // Delete notification configs
         val deleteResponse = deleteConfigs(deletedIds)
         val deletedObject = deleteResponse.get("delete_response_list").asJsonObject
         deletedIds.forEach {
@@ -166,14 +167,14 @@ class DeleteNotificationConfigIT : PluginRestTestCase() {
         }
         Thread.sleep(1000)
 
-        // Get notification configs after delete
+        // Get remaining notification configs by ID list
         val getAfterDelete = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs",
+            "$PLUGIN_BASE_URI/configs?config_id_list=${remainingIds.joinToString(",")}",
             "",
             RestStatus.OK.status
         )
-        verifyMultiConfigIdEquals(remainingIds, getAfterDelete)
+        verifyMultiConfigIdEquals(remainingIds, getAfterDelete, remainingIds.size)
         Thread.sleep(100)
     }
 }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/integtest/config/QueryNotificationConfigIT.kt
@@ -75,11 +75,11 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
     }
 
     fun `test Get multiple notification config as part of query`() {
-        (1..5).map { createConfig() }.toSet()
+        (1..2).map { createConfig() }.toSet()
         Thread.sleep(100)
-        (1..5).map { createConfig() }.toSet()
-        val configIds: Set<String> = (1..5).map { createConfig() }.toSet()
-        (1..5).map { createConfig() }.toSet()
+        (1..2).map { createConfig() }.toSet()
+        val configIds: Set<String> = (1..2).map { createConfig() }.toSet()
+        (1..2).map { createConfig() }.toSet()
         Thread.sleep(1000)
         // Get notification config with query parameter
         val getConfigResponse = executeRequest(
@@ -93,7 +93,7 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
     }
 
     fun `test Get all notification config`() {
-        val configIds: Set<String> = (1..20).map { createConfig() }.toSet()
+        val configIds: Set<String> = (1..5).map { createConfig() }.toSet()
         refreshAllIndices()
 
         // Get all notification configs
@@ -107,9 +107,9 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
     }
 
     fun `test Get paginated notification config using from_index and max_items`() {
-        val firstConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
-        val secondConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
-        val thirdConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val firstConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
+        val secondConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
+        val thirdConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         val allConfigIds = firstConfigIds.union(secondConfigIds).union(thirdConfigIds)
         Thread.sleep(1000)
 
@@ -123,56 +123,56 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         verifyMultiConfigIdEquals(allConfigIds, getAllConfigResponse, allConfigIds.size)
         Thread.sleep(100)
 
-        // Get first 10 notification configs
+        // Get first 3 notification configs
         val getFirstConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?from_index=0&max_items=10",
+            "$PLUGIN_BASE_URI/configs?from_index=0&max_items=3",
             "",
             RestStatus.OK.status
         )
         verifyMultiConfigIdEquals(firstConfigIds, getFirstConfigResponse, allConfigIds.size)
 
-        // Get first 10 notification configs without from_index
+        // Get first 3 notification configs without from_index
         val getFirstConfigResponseWithoutFromIndex = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?max_items=10",
+            "$PLUGIN_BASE_URI/configs?max_items=3",
             "",
             RestStatus.OK.status
         )
         verifyMultiConfigIdEquals(firstConfigIds, getFirstConfigResponseWithoutFromIndex, allConfigIds.size)
 
-        // Get second 10 notification configs
+        // Get second 3 notification configs
         val getSecondConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?from_index=10&max_items=10",
+            "$PLUGIN_BASE_URI/configs?from_index=3&max_items=3",
             "",
             RestStatus.OK.status
         )
         verifyMultiConfigIdEquals(secondConfigIds, getSecondConfigResponse, allConfigIds.size)
 
-        // Get third 10 notification configs
+        // Get third 3 notification configs
         val getThirdConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?from_index=20&max_items=10",
+            "$PLUGIN_BASE_URI/configs?from_index=6&max_items=3",
             "",
             RestStatus.OK.status
         )
         verifyMultiConfigIdEquals(thirdConfigIds, getThirdConfigResponse, allConfigIds.size)
 
-        // Get all items after 10 notification configs
-        val getAfter10ConfigResponse = executeRequest(
+        // Get all items after 3 notification configs
+        val getAfter3ConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?from_index=10",
+            "$PLUGIN_BASE_URI/configs?from_index=3",
             "",
             RestStatus.OK.status
         )
-        verifyMultiConfigIdEquals(secondConfigIds.union(thirdConfigIds), getAfter10ConfigResponse, allConfigIds.size)
+        verifyMultiConfigIdEquals(secondConfigIds.union(thirdConfigIds), getAfter3ConfigResponse, allConfigIds.size)
     }
 
     fun `test Get descending paginated notification config using from_index and max_items`() {
-        val firstConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
-        val secondConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
-        val thirdConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val firstConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
+        val secondConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
+        val thirdConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         val allConfigIds = firstConfigIds.union(secondConfigIds).union(thirdConfigIds)
         Thread.sleep(1000)
 
@@ -186,32 +186,32 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
         verifyMultiConfigIdEquals(allConfigIds, getAllConfigResponse, allConfigIds.size)
         Thread.sleep(100)
 
-        // Get first 10 notification configs
+        // Get first 3 notification configs (desc order returns most-recently created first)
         val getFirstConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?from_index=0&max_items=10&sort_order=desc",
+            "$PLUGIN_BASE_URI/configs?from_index=0&max_items=3&sort_order=desc",
             "",
             RestStatus.OK.status
         )
         verifyMultiConfigIdEquals(thirdConfigIds, getFirstConfigResponse, allConfigIds.size)
 
-        // Get last 10 notification configs
+        // Get last 3 notification configs (desc order, offset 6)
         val getThirdConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?from_index=20&max_items=10&sort_order=desc",
+            "$PLUGIN_BASE_URI/configs?from_index=6&max_items=3&sort_order=desc",
             "",
             RestStatus.OK.status
         )
         verifyMultiConfigIdEquals(firstConfigIds, getThirdConfigResponse, allConfigIds.size)
 
-        // Get all items after 10 notification configs
-        val getAfter10ConfigResponse = executeRequest(
+        // Get all items after 3 notification configs (desc order)
+        val getAfter3ConfigResponse = executeRequest(
             RestRequest.Method.GET.name,
-            "$PLUGIN_BASE_URI/configs?from_index=10&sort_order=desc",
+            "$PLUGIN_BASE_URI/configs?from_index=3&sort_order=desc",
             "",
             RestStatus.OK.status
         )
-        verifyMultiConfigIdEquals(secondConfigIds.union(firstConfigIds), getAfter10ConfigResponse, allConfigIds.size)
+        verifyMultiConfigIdEquals(secondConfigIds.union(firstConfigIds), getAfter3ConfigResponse, allConfigIds.size)
     }
 
     fun `test Get sorted notification config using metadata keyword sort_field(created_time_ms)`() {
@@ -408,8 +408,8 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
     }
 
     fun `test Get filtered notification config using keyword filter_param_list(is_enabled)`() {
-        val enabledConfigIds: Set<String> = (1..10).map { createConfig(isEnabled = true) }.toSet()
-        val disabledConfigIds: Set<String> = (1..10).map { createConfig(isEnabled = false) }.toSet()
+        val enabledConfigIds: Set<String> = (1..4).map { createConfig(isEnabled = true) }.toSet()
+        val disabledConfigIds: Set<String> = (1..4).map { createConfig(isEnabled = false) }.toSet()
         Thread.sleep(1000)
 
         // Get notification configs with is_enabled=true
@@ -462,13 +462,13 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
 
     fun `test Get filtered notification config using keyword filter_param_list(last_updated_time_ms)`() {
         val initialTime = Instant.now()
-        val initialConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val initialConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         Thread.sleep(1000)
         val middleTime = Instant.now()
-        val middleConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val middleConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         Thread.sleep(1000)
         val finalTime = Instant.now()
-        val finalConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val finalConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         Thread.sleep(1000)
         val endTime = Instant.now()
 
@@ -505,13 +505,13 @@ class QueryNotificationConfigIT : PluginRestTestCase() {
 
     fun `test Get filtered notification config using keyword filter_param_list(created_time_ms)`() {
         val initialTime = Instant.now()
-        val initialConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val initialConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         Thread.sleep(1000)
         val middleTime = Instant.now()
-        val middleConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val middleConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         Thread.sleep(1000)
         val finalTime = Instant.now()
-        val finalConfigIds: Set<String> = (1..10).map { createConfig() }.toSet()
+        val finalConfigIds: Set<String> = (1..3).map { createConfig() }.toSet()
         Thread.sleep(1000)
         val endTime = Instant.now()
 

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
@@ -81,6 +81,10 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.MAX_NOTIFICATION_CONFIGS,
+                    PluginSettings.MAX_NOTIFICATION_GROUPS,
+                    PluginSettings.MAX_NOTIFICATION_SENDERS,
+                    PluginSettings.MAX_ACTIVE_RESPONSES,
                     PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
                     PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS
                 )
@@ -107,6 +111,10 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.MAX_NOTIFICATION_CONFIGS,
+                    PluginSettings.MAX_NOTIFICATION_GROUPS,
+                    PluginSettings.MAX_NOTIFICATION_SENDERS,
+                    PluginSettings.MAX_ACTIVE_RESPONSES,
                     PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
                     PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS
                 )
@@ -136,6 +144,10 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.MAX_NOTIFICATION_CONFIGS,
+                    PluginSettings.MAX_NOTIFICATION_GROUPS,
+                    PluginSettings.MAX_NOTIFICATION_SENDERS,
+                    PluginSettings.MAX_ACTIVE_RESPONSES,
                     PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
                     PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.FILTER_BY_BACKEND_ROLES
@@ -161,6 +173,10 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.MAX_NOTIFICATION_CONFIGS,
+                    PluginSettings.MAX_NOTIFICATION_GROUPS,
+                    PluginSettings.MAX_NOTIFICATION_SENDERS,
+                    PluginSettings.MAX_ACTIVE_RESPONSES,
                     PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
                     PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES,
@@ -187,6 +203,10 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.MAX_NOTIFICATION_CONFIGS,
+                    PluginSettings.MAX_NOTIFICATION_GROUPS,
+                    PluginSettings.MAX_NOTIFICATION_SENDERS,
+                    PluginSettings.MAX_ACTIVE_RESPONSES,
                     PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
                     PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES,
@@ -212,6 +232,10 @@ internal class PluginSettingsTests {
                 setOf(
                     PluginSettings.OPERATION_TIMEOUT_MS,
                     PluginSettings.DEFAULT_ITEMS_QUERY_COUNT,
+                    PluginSettings.MAX_NOTIFICATION_CONFIGS,
+                    PluginSettings.MAX_NOTIFICATION_GROUPS,
+                    PluginSettings.MAX_NOTIFICATION_SENDERS,
+                    PluginSettings.MAX_ACTIVE_RESPONSES,
                     PluginSettings.ACTIVE_RESPONSE_BULK_FLUSH_INTERVAL_MS,
                     PluginSettings.ACTIVE_RESPONSE_BULK_MAX_ACTIONS,
                     PluginSettings.LEGACY_ALERTING_FILTER_BY_BACKEND_ROLES,


### PR DESCRIPTION
### Description
This PR implements limits for the number of notification channels, senders, groups and active responses.

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1276

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
