### PR TITLE
Migrate GHA workflows runner to AWS hosted

### DIFF
--- a/.github/workflows/5_builderpackage_notifications.yml
+++ b/.github/workflows/5_builderpackage_notifications.yml
@@ -132,7 +132,7 @@ jobs:
           cp -a "$HOME/.m2" /home/builder/.m2 2>/dev/null || true
           chown -R builder:builder "$GITHUB_WORKSPACE" /home/builder
           cd notifications
-          runuser -u builder -- env "JAVA_HOME=$JAVA_HOME" "PATH=$PATH" \
+          runuser -u builder -- env "JAVA_HOME=$JAVA_HOME" "PATH=$PATH" "GRADLE_USER_HOME=/home/builder/.gradle" \
             ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=${{ inputs.revision }}"
 
       - name: Create Artifact Path

--- a/.github/workflows/5_builderpackage_notifications.yml
+++ b/.github/workflows/5_builderpackage_notifications.yml
@@ -28,7 +28,8 @@ on:
 
 jobs:
   branches:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       common_utils_ref: ${{ steps.resolve.outputs.wazuh_indexer_common_utils_branch }}
     steps:
@@ -45,7 +46,8 @@ jobs:
           echo "Common Utils branch: ${{ steps.resolve.outputs.wazuh_indexer_common_utils_branch }}"
 
   get-version:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -59,7 +61,8 @@ jobs:
         run: echo "version=$(jq -r .version<VERSION.json)" >> "$GITHUB_OUTPUT"
 
   publish-common-utils:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [branches, get-version]
     steps:
       - name: Restore Maven Local Cache
@@ -90,13 +93,14 @@ jobs:
       fail-fast: false
       matrix:
         java: [21, 25]
-        os:
-          - ubuntu-24.04-arm  # arm64-preview
-          - ubuntu-24.04  # x64
+        arch:
+          - amd  # x64
+          - arm  # arm64
 
     # Job name
-    name: Build Notifications with JDK ${{ matrix.java }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build Notifications with JDK ${{ matrix.java }} on ${{ matrix.arch }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-${{ matrix.arch }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Set up JDK ${{ matrix.java }}
@@ -119,9 +123,17 @@ jobs:
             m2-common-utils-${{ github.ref_name }}-
 
       - name: Build with Gradle
+        # The self-hosted runner executes as root, but OpenSearch test clusters
+        # (launched by integTest during `build`) refuse to run as root. Build as
+        # a dedicated non-root user instead.
         run: |
+          id -u builder &>/dev/null || useradd -m builder
+          # Hand the build user the workspace and the restored Maven local cache.
+          cp -a "$HOME/.m2" /home/builder/.m2 2>/dev/null || true
+          chown -R builder:builder "$GITHUB_WORKSPACE" /home/builder
           cd notifications
-          ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=${{ inputs.revision }}"
+          runuser -u builder -- env "JAVA_HOME=$JAVA_HOME" "PATH=$PATH" \
+            ./gradlew build "-Dversion=${{ needs.get-version.outputs.version }}" "-Drevision=${{ inputs.revision }}"
 
       - name: Create Artifact Path
         run: |
@@ -133,11 +145,11 @@ jobs:
       - name: Upload Artifacts for notifications plugin
         uses: actions/upload-artifact@v7
         with:
-          name: notifications-plugin-${{ matrix.os }}-JDK${{ matrix.java }}
+          name: notifications-plugin-${{ matrix.arch }}-JDK${{ matrix.java }}
           path: notifications-build/notifications
 
       - name: Upload Artifacts for notifications-core plugin
         uses: actions/upload-artifact@v7
         with:
-          name: notifications-core-plugin-${{ matrix.os }}-JDK${{ matrix.java }}
+          name: notifications-core-plugin-${{ matrix.arch }}-JDK${{ matrix.java }}
           path: notifications-build/notifications-core

--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -36,7 +36,8 @@ on:
 jobs:
   bump:
     name: Repository bumper
-    runs-on: ubuntu-22.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -7,7 +7,8 @@ jobs:
   # Enforces the update of a changelog file on every pull request
   verify-changelog:
     if: ${{ !github.event.pull_request.draft && github.repository == 'wazuh/wazuh-indexer-notifications' }}
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v6
       - uses: dangoslen/changelog-enforcer@v3

--- a/.github/workflows/5_codequality_email.yml
+++ b/.github/workflows/5_codequality_email.yml
@@ -7,7 +7,8 @@ jobs:
   # Checks if the email domain is @wazuh.com, if not the workflow will fail
   verify-email:
     if: ${{ !github.event.pull_request.draft && github.repository == 'wazuh/wazuh-indexer-notifications' }}
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@main
         with:

--- a/.github/workflows/5_codequality_signed_commits.yml
+++ b/.github/workflows/5_codequality_signed_commits.yml
@@ -7,7 +7,8 @@ jobs:
   # Checks if the commits are signed, if not the workflow will fail
   verify-signed-commits:
     if: ${{ !github.event.pull_request.draft && github.repository == 'wazuh/wazuh-indexer-notifications' }}
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       contents: read
     steps:

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   branches:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       common_utils_ref: ${{ steps.resolve.outputs.wazuh_indexer_common_utils_branch }}
     steps:
@@ -30,7 +31,8 @@ jobs:
           echo "Common Utils branch: ${{ steps.resolve.outputs.wazuh_indexer_common_utils_branch }}"
 
   get-version:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -44,7 +46,8 @@ jobs:
         run: echo "version=$(jq -r .version<VERSION.json)" >> "$GITHUB_OUTPUT"
 
   publish-common-utils:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [branches, get-version]
     steps:
       - name: Publish to Maven Local
@@ -60,7 +63,8 @@ jobs:
           key: ${{ github.run_id }}-common-utils
 
   call-test-workflow:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [branches, get-version, publish-common-utils]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -80,5 +80,14 @@ jobs:
           key: ${{ github.run_id }}-common-utils
 
       - name: Run Gradle check
-        run: ./gradlew check
         working-directory: ./notifications
+        # The self-hosted runner executes as root, but OpenSearch test clusters
+        # (launched by integTest during `check`) refuse to run as root. Run as a
+        # dedicated non-root user instead.
+        run: |
+          id -u builder &>/dev/null || useradd -m builder
+          # Hand the build user the workspace and the restored Maven local cache.
+          cp -a "$HOME/.m2" /home/builder/.m2 2>/dev/null || true
+          chown -R builder:builder "$GITHUB_WORKSPACE" /home/builder
+          runuser -u builder -- env "JAVA_HOME=$JAVA_HOME" "PATH=$PATH" "GRADLE_USER_HOME=/home/builder/.gradle" \
+            ./gradlew check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,8 @@ on:
 
 jobs:
   branches:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     outputs:
       common_utils_plugin_ref: ${{ steps.branches.outputs.wazuh_indexer_common_utils_branch }}
       common_utils_sha: ${{ steps.common-utils-sha.outputs.sha }}
@@ -36,7 +37,8 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
   get-version:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: branches
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -51,7 +53,8 @@ jobs:
         run: echo "version=$(jq -r .version<VERSION.json)" >> "$GITHUB_OUTPUT"
 
   publish-common-utils:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     needs: [ branches, get-version ]
     steps:
       - name: Restore Maven Local Cache
@@ -84,7 +87,8 @@ jobs:
     #   - https://gh.io/using-larger-runners
     # Consider using larger runners for possible analysis time improvements.
     needs: [ branches, get-version, publish-common-utils ]
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       actions: read

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   linkchecker:
-    runs-on: ubuntu-24.04
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     permissions:
       contents: read
 


### PR DESCRIPTION
### Description
This PR updated the GHA workflow to use the AWS hosted runners

### Related Issues
Closes IDR5263
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
