### PR TITLE
Add `bump-issue-link` support

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -32,6 +32,10 @@ on:
         default: false
         required: false
         type: boolean
+      bump-issue-link:
+        description: 'Issue link used in the original bump (required for revert if different from issue-link)'
+        required: false
+        type: string
 
 jobs:
   bump:
@@ -147,8 +151,18 @@ jobs:
         id: revert_step
         if: inputs.revert == true
         run: |
+          # 1. Get the current issue number (for the new revert branch/PR)
           ISSUE_NUMBER=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
-          BUMP_BRANCH="enhancement/wqa${ISSUE_NUMBER}-bump-${{ github.ref_name }}"
+
+          # 2. Get the issue number from the original bump (if provided; otherwise, defaults to the current one)
+          if [ -n "${{ inputs.bump-issue-link }}" ]; then
+            BUMP_ISSUE_NUMBER=$(echo "${{ inputs.bump-issue-link }}" | awk -F'/' '{print $NF}')
+          else
+            BUMP_ISSUE_NUMBER=$ISSUE_NUMBER
+          fi
+
+          # 3. Search for the original bump branch using the obtained BUMP ISSUE number
+          BUMP_BRANCH="enhancement/wqa${BUMP_ISSUE_NUMBER}-bump-${{ github.ref_name }}"
 
           PR_NUMBER=$(gh pr list --head "$BUMP_BRANCH" --base "${{ github.ref_name }}" --state merged --json number --jq '.[0].number')
 


### PR DESCRIPTION
### Description
This PR adds support to the new functionality `bump-issue-link` so now the bumper can track a different issue, not only the PR related one

### Related Issues
Resolves #116 

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
