### PR TITLE
Delete duplicated permissions

### DIFF
--- a/notifications/core/src/main/plugin-metadata/plugin-security.policy
+++ b/notifications/core/src/main/plugin-metadata/plugin-security.policy
@@ -16,8 +16,6 @@ grant {
     // needed because of problems in ClientConfiguration
     // TODO: get these fixed in aws sdk
     permission java.lang.RuntimePermission "accessDeclaredMembers";
-    permission java.lang.RuntimePermission "getClassLoader";
-    permission java.net.SocketPermission "*", "connect";
     // Needed because of problems in AmazonSNS:
     // When no region is set on a STSClient instance, the
     // AWS SDK loads all known partitions from a JSON file and

--- a/notifications/notifications/src/main/plugin-metadata/plugin-security.policy
+++ b/notifications/notifications/src/main/plugin-metadata/plugin-security.policy
@@ -16,8 +16,6 @@ grant {
     // needed because of problems in ClientConfiguration
     // TODO: get these fixed in aws sdk
     permission java.lang.RuntimePermission "accessDeclaredMembers";
-    permission java.lang.RuntimePermission "getClassLoader";
-    permission java.net.SocketPermission "*", "connect";
     // Needed because of problems in AmazonSNS:
     // When no region is set on a STSClient instance, the
     // AWS SDK loads all known partitions from a JSON file and


### PR DESCRIPTION
### Description
This PR deleted duplicated permissions to adjust to the least-privilege principle

### Related Issues
Resolves https://github.com/wazuh/wazuh-indexer-plugins/issues/1278

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
