### PR TITLE
Pin workflow references to the release branch instead of main

### DIFF
--- a/.github/workflows/5_builderpackage_notifications.yml
+++ b/.github/workflows/5_builderpackage_notifications.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Resolve branches
         id: resolve
-        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@main
+        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@5.0.0
         with:
           branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
@@ -75,7 +75,7 @@ jobs:
             m2-common-utils-${{ github.ref_name }}-
 
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@main
+        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: ${{ inputs.revision }}

--- a/.github/workflows/5_codequality_email.yml
+++ b/.github/workflows/5_codequality_email.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       - codebuild-github-actions-codebuild-runner-indexer-amd-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@main
+      - uses: wazuh/wazuh-indexer/.github/actions/5_codeanalysis_emailchecker@5.0.0
         with:
             email_domain: 'wazuh.com, @users.noreply.github.com'
             github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/5_testintegration_gradlecheck.yml
+++ b/.github/workflows/5_testintegration_gradlecheck.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Resolve branches
         id: resolve
-        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@main
+        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@5.0.0
         with:
           branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
@@ -51,7 +51,7 @@ jobs:
     needs: [branches, get-version]
     steps:
       - name: Publish to Maven Local
-        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@main
+        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Resolve branches
         id: branches
-        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@main
+        uses: wazuh/wazuh-indexer/.github/actions/5_builderpackage_indexer_branch_resolver@5.0.0
         with:
           branch: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
       - name: Get common-utils latest commit
@@ -67,7 +67,7 @@ jobs:
             m2-common-utils-${{ github.ref_name }}-${{ needs.branches.outputs.common_utils_plugin_ref }}-${{ needs.branches.outputs.common_utils_sha }}-
       - name: Publish to Maven Local
         if: steps.cache-common-utils.outputs.cache-hit != 'true'
-        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@main
+        uses: wazuh/wazuh-indexer-common-utils/.github/actions/5_local_maven_publisher@5.0.0
         with:
           version: ${{ needs.get-version.outputs.version }}
           revision: 0

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -3,7 +3,9 @@
 # =========================
 # Repository Bumper Script
 # =========================
-# This script updates the VERSION.json file for a new version release.
+# This script updates the VERSION.json file for a new version release, then
+# pins any "@main" workflow/action references to other repos to the current
+# branch (see workflow_refs_sync.sh).
 #
 # It takes three arguments:
 # 1. The new version to set (e.g., 4.5.0)
@@ -169,6 +171,7 @@ function main() {
     check_jq_installed
     validate_inputs "$version" "$stage"
     update_version_file "$version" "$stage"
+    bash "$(dirname "${BASH_SOURCE[0]}")/workflow_refs_sync.sh"
     log "Update complete."
 }
 

--- a/tools/workflow_refs_sync.sh
+++ b/tools/workflow_refs_sync.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# =========================
+# Workflow References Sync
+# =========================
+# On any branch other than main, finds "uses: wazuh/<repo>/...@main" reusable
+# workflow/action references in .github/workflows/*.yml and pins them to the
+# current branch, for every referenced repo that actually has a branch with
+# that name. Called by repository_bumper.sh after every bump.
+#
+# On main, does nothing , main's references to other repos' main are correct
+# as they are.
+
+set -euo pipefail
+
+function log() {
+    echo "[$(date +"%Y-%m-%d %H:%M:%S")] $1"
+}
+
+# ====
+# Determine the branch this script is running on. In GitHub Actions,
+# actions/checkout leaves the repo in a detached HEAD state, so
+# `git rev-parse --abbrev-ref HEAD` would return the literal string "HEAD"
+# instead of the branch name. GITHUB_REF_NAME is set automatically by the
+# Actions runner and is used first; git is only a fallback for local runs.
+# ====
+function get_current_branch() {
+    if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+        echo "$GITHUB_REF_NAME"
+    else
+        git rev-parse --abbrev-ref HEAD
+    fi
+}
+
+# ====
+# Check whether the given wazuh/<repo> has a branch with the given name.
+# Arguments:
+#   $1 - repo (e.g. wazuh-indexer)
+#   $2 - branch
+# ====
+function remote_branch_exists() {
+    local repo="$1"
+    local branch="$2"
+    git ls-remote --exit-code --heads "https://github.com/wazuh/${repo}.git" "$branch" &>/dev/null
+}
+
+# ====
+# Every distinct repo referenced as "wazuh/<repo>/...@main" across
+# .github/workflows/*.yml.
+# ====
+function find_referenced_repos() {
+    local matches
+    matches=$(grep -rhoE 'uses:[[:space:]]*wazuh/[^/[:space:]]+/[^[:space:]]*@main' .github/workflows/*.yml 2>/dev/null || true)
+
+    [[ -z "$matches" ]] && return 0
+
+    printf '%s\n' "$matches" | sed -E 's#.*wazuh/([^/]+)/.*#\1#' | sort -u
+}
+
+# ====
+# Replace "@main" with "@<branch>" in every "wazuh/<repo>/...@main" reference
+# across .github/workflows/*.yml.
+# Arguments:
+#   $1 - repo (e.g. wazuh-indexer)
+#   $2 - branch to pin to
+# ====
+function pin_repo_references() {
+    local repo="$1"
+    local branch="$2"
+    local escaped_branch
+    escaped_branch=$(printf '%s' "$branch" | sed -e 's/[\\&#]/\\&/g')
+
+    local f
+    for f in .github/workflows/*.yml; do
+        [[ -f "$f" ]] || continue
+        if grep -qE "uses:[[:space:]]*wazuh/${repo}/.*@main" "$f"; then
+            sed -i -E "s#(uses:[[:space:]]*wazuh/${repo}/[^[:space:]]+)@main#\1@${escaped_branch}#" "$f"
+            log "Pinned wazuh/$repo references to '$branch' in $f"
+        fi
+    done
+}
+
+# ====
+# Main logic
+# ====
+function main() {
+    local branch
+    branch="$(get_current_branch)"
+
+    if [[ "$branch" == "main" ]]; then
+        log "Running on main; leaving @main references to other repos untouched."
+        return 0
+    fi
+
+    local repo
+    while IFS= read -r repo; do
+        [[ -z "$repo" ]] && continue
+        if remote_branch_exists "$repo" "$branch"; then
+            pin_repo_references "$repo" "$branch"
+        else
+            log "No branch '$branch' in wazuh/$repo; leaving its @main references untouched."
+        fi
+    done < <(find_referenced_repos)
+}
+
+main "$@"


### PR DESCRIPTION
### Description
Fixes CI workflows that call reusable workflows from other repos using `@main`, which breaks once a branch diverges from main . Manually pins the current `@main` references in this branch to `5.0.0`, and adds `workflow_refs_sync.sh` (called by the repository bumper on every bump) so that, any `@main` reference to another repo gets automatically pinned to the current branch whenever a release branch is bumped.

### Issues Resolved
Resolves IDR5387