### PR TITLE
Adopt the standard PR template and no-changelog label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,75 @@
-### Description
-[Describe what this change achieves]
+## Description
 
-### Related Issues
-Resolves #[Issue number to be closed when this PR is merged]
-<!-- List any other related issues here -->
+<!--
+Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.
 
-### Check List
-- [ ] New functionality includes testing.
-- [ ] New functionality has been documented.
-- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
-- [ ] Commits are signed per the DCO using `--signoff`.
-- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
+If this pull request resolves an existing issue, reference it here. For example:
+Closes #<issue_number>
+-->
 
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/notifications/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
+## Proposed Changes
+
+<!--
+Summarize the changes made in this pull request. Include:
+- Features added
+- Bugs fixed
+- Any relevant technical details
+-->
+
+### Results and Evidence
+
+<!--
+Provide evidence of the changes made, such as:
+- Logs
+- Screenshots
+- Before/after comparisons
+-->
+
+### Artifacts Affected
+
+<!--
+List the artifacts impacted by this pull request, such as:
+- Executables (specify platforms if applicable)
+- Default configuration files
+- Packages
+-->
+
+### Configuration Changes
+
+<!--
+If applicable, list any configuration changes introduced by this pull request, including:
+- New configuration parameters
+- Changes to default values
+- Backward compatibility notes
+-->
+
+### Documentation Updates
+
+<!--
+If applicable, list the sections of documentation that have been updated as part of this pull request.
+-->
+
+### Tests Introduced
+
+<!--
+If applicable, describe any new unit or integration tests added as part of this pull request. Include:
+- Scope of the tests
+- Any relevant details about test coverage
+-->
+
+## Review Checklist
+
+<!--
+List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
+-->
+
+- [ ] Code changes reviewed
+- [ ] Relevant evidence provided
+- [ ] Tests cover the new functionality
+- [ ] Configuration changes documented
+- [ ] Developer documentation reflects the changes
+- [ ] Meets requirements and/or definition of done
+- [ ] No unresolved dependencies with other issues
+- [ ] PR is linked to the relevant issue(s)
+- [ ] Correct labels applied (e.g., `no-changelog`)
+- [ ] ...

--- a/.github/workflows/5_codequality_changelog.yml
+++ b/.github/workflows/5_codequality_changelog.yml
@@ -13,5 +13,5 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: "autocut, skip-changelog"
+          skipLabels: "no-changelog"
           changeLogPath: "CHANGELOG.md"


### PR DESCRIPTION
### Description
Updates the PR template to the documented structure and switches the changelog enforcer workflow to accept only the `no-changelog` skip label, instead of `autocut`/`skip-changelog`.

### Related Issues
Related to IDR5504
