### PR TITLE
Fix default channel version conflict race on cluster restart

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/NotificationPlugin.kt
@@ -6,6 +6,7 @@
 package org.opensearch.notifications
 
 import org.opensearch.action.ActionRequest
+import org.opensearch.cluster.LocalNodeClusterManagerListener
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver
 import org.opensearch.cluster.node.DiscoveryNode
 import org.opensearch.cluster.node.DiscoveryNodes
@@ -69,6 +70,7 @@ import org.opensearch.script.ScriptService
 import org.opensearch.threadpool.ThreadPool
 import org.opensearch.transport.client.Client
 import org.opensearch.watcher.ResourceWatcherService
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Supplier
 
 /**
@@ -237,9 +239,30 @@ class NotificationPlugin : ActionPlugin, ClusterPlugin, Plugin(), NotificationCo
      * {@inheritDoc}
      */
     override fun onNodeStarted(localNode: DiscoveryNode) {
-        if (localNode.isClusterManagerNode) {
-            log.info("$LOG_PREFIX:Initializing default notification channels on cluster manager node")
-            DefaultChannelInitializer.initialize()
+        // isClusterManagerNode is a role check (cluster-manager-eligible) that is true on every
+        // eligible node, not just the elected one, and at onNodeStarted time an election may not
+        // have finished yet. A LocalNodeClusterManagerListener instead fires once this specific
+        // node actually becomes the elected leader, so initialization only ever runs on a single
+        // node per cluster, avoiding the race where multiple nodes try to create the same default
+        // channel documents.
+        val initialized = AtomicBoolean(false)
+        val listener = object : LocalNodeClusterManagerListener {
+            override fun onClusterManager() {
+                if (!initialized.compareAndSet(false, true)) {
+                    return
+                }
+                log.info("$LOG_PREFIX:Initializing default notification channels on elected cluster manager node")
+                DefaultChannelInitializer.initialize()
+            }
+
+            override fun offClusterManager() {}
+        }
+        clusterService.addLocalNodeClusterManagerListener(listener)
+
+        // The listener only fires on transitions. If the election already happened before this
+        // method runs, trigger the callback explicitly.
+        if (clusterService.state().nodes().isLocalNodeElectedClusterManager) {
+            listener.onClusterManager()
         }
     }
 }

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/NotificationPluginTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/NotificationPluginTests.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.notifications
+
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.opensearch.cluster.ClusterState
+import org.opensearch.cluster.LocalNodeClusterManagerListener
+import org.opensearch.cluster.node.DiscoveryNode
+import org.opensearch.cluster.node.DiscoveryNodes
+import org.opensearch.cluster.service.ClusterService
+
+internal class NotificationPluginTests {
+    private lateinit var plugin: NotificationPlugin
+    private lateinit var clusterService: ClusterService
+    private lateinit var clusterState: ClusterState
+    private lateinit var discoveryNodes: DiscoveryNodes
+    private lateinit var localNode: DiscoveryNode
+
+    @BeforeEach
+    fun setup() {
+        plugin = NotificationPlugin()
+        clusterService = mock(ClusterService::class.java)
+        clusterState = mock(ClusterState::class.java)
+        discoveryNodes = mock(DiscoveryNodes::class.java)
+        localNode = mock(DiscoveryNode::class.java)
+
+        plugin.clusterService = clusterService
+        whenever(clusterService.state()).thenReturn(clusterState)
+        whenever(clusterState.nodes()).thenReturn(discoveryNodes)
+    }
+
+    @Test
+    fun `test onNodeStarted registers a local node cluster manager listener`() {
+        // Registering a LocalNodeClusterManagerListener, instead of relying on the role check
+        // that used to run at onNodeStarted time, is what lets initialization wait for (and react
+        // to) this specific node actually winning the election, instead of firing on every
+        // cluster-manager-eligible node during a full cluster restart.
+        whenever(discoveryNodes.isLocalNodeElectedClusterManager).thenReturn(false)
+
+        plugin.onNodeStarted(localNode)
+
+        verify(clusterService).addLocalNodeClusterManagerListener(any())
+    }
+
+    @Test
+    fun `test onNodeStarted triggers the listener immediately if already elected`() {
+        whenever(discoveryNodes.isLocalNodeElectedClusterManager).thenReturn(true)
+
+        assertDoesNotThrow { plugin.onNodeStarted(localNode) }
+
+        verify(clusterService).addLocalNodeClusterManagerListener(any())
+    }
+
+    @Test
+    fun `test the registered listener is safe to invoke repeatedly and does not throw`() {
+        whenever(discoveryNodes.isLocalNodeElectedClusterManager).thenReturn(false)
+
+        val captor = argumentCaptor<LocalNodeClusterManagerListener>()
+        plugin.onNodeStarted(localNode)
+        verify(clusterService).addLocalNodeClusterManagerListener(captor.capture())
+
+        val listener = captor.firstValue
+        assertDoesNotThrow {
+            listener.onClusterManager()
+            listener.onClusterManager()
+            listener.offClusterManager()
+        }
+    }
+}


### PR DESCRIPTION
### Description
On a full cluster restart, `onNodeStarted` triggered default notification channel initialization on every cluster-manager-eligible node (a role check), instead of only the node that actually won the election. This made every eligible node race to create the same 4 default channel documents, logging a `Document version conflict` ERROR for every node that lost the race (even though the documents were correctly left intact) . Replaced the role check with a `LocalNodeClusterManagerListener`, so initialization only ever runs once, on the single elected cluster-manager node.

### Related Issues
Resolves #136
