### PR TITLE
Remove notification settings maximum values

### DIFF
--- a/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
+++ b/notifications/notifications/src/main/kotlin/org/opensearch/notifications/settings/PluginSettings.kt
@@ -121,14 +121,9 @@ internal object PluginSettings {
     private const val MINIMUM_ITEMS_QUERY_COUNT = 10
 
     /**
-     * Maximum allowed value for the max notification configs setting.
-     */
-    private const val MAXIMUM_MAX_NOTIFICATION_CONFIGS = 40
-
-    /**
      * Default maximum number of notification channel configurations.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = MAXIMUM_MAX_NOTIFICATION_CONFIGS
+    private const val DEFAULT_MAX_NOTIFICATION_CONFIGS_VALUE = 40
 
     /**
      * Minimum allowed value for the max notification configs setting.
@@ -136,14 +131,9 @@ internal object PluginSettings {
     private const val MINIMUM_MAX_NOTIFICATION_CONFIGS = 0
 
     /**
-     * Maximum allowed value for the max notification groups setting.
-     */
-    private const val MAXIMUM_MAX_NOTIFICATION_GROUPS = 10
-
-    /**
      * Default maximum number of notification groups.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_GROUPS_VALUE = MAXIMUM_MAX_NOTIFICATION_GROUPS
+    private const val DEFAULT_MAX_NOTIFICATION_GROUPS_VALUE = 10
 
     /**
      * Minimum allowed value for the max notification groups setting.
@@ -151,14 +141,9 @@ internal object PluginSettings {
     private const val MINIMUM_MAX_NOTIFICATION_GROUPS = 0
 
     /**
-     * Maximum allowed value for the max notification senders setting.
-     */
-    private const val MAXIMUM_MAX_NOTIFICATION_SENDERS = 5
-
-    /**
      * Default maximum number of notification senders.
      */
-    private const val DEFAULT_MAX_NOTIFICATION_SENDERS_VALUE = MAXIMUM_MAX_NOTIFICATION_SENDERS
+    private const val DEFAULT_MAX_NOTIFICATION_SENDERS_VALUE = 5
 
     /**
      * Minimum allowed value for the max notification senders setting.
@@ -166,14 +151,9 @@ internal object PluginSettings {
     private const val MINIMUM_MAX_NOTIFICATION_SENDERS = 0
 
     /**
-     * Maximum allowed value for the max active responses setting.
-     */
-    private const val MAXIMUM_MAX_ACTIVE_RESPONSES = 10
-
-    /**
      * Default maximum number of active response configurations.
      */
-    private const val DEFAULT_MAX_ACTIVE_RESPONSES_VALUE = MAXIMUM_MAX_ACTIVE_RESPONSES
+    private const val DEFAULT_MAX_ACTIVE_RESPONSES_VALUE = 10
 
     /**
      * Minimum allowed value for the max active responses setting.
@@ -313,7 +293,6 @@ internal object PluginSettings {
         MAX_NOTIFICATION_CONFIGS_KEY,
         defaultSettings[MAX_NOTIFICATION_CONFIGS_KEY]!!.toInt(),
         MINIMUM_MAX_NOTIFICATION_CONFIGS,
-        MAXIMUM_MAX_NOTIFICATION_CONFIGS,
         NodeScope,
         Dynamic
     )
@@ -322,7 +301,6 @@ internal object PluginSettings {
         MAX_NOTIFICATION_GROUPS_KEY,
         defaultSettings[MAX_NOTIFICATION_GROUPS_KEY]!!.toInt(),
         MINIMUM_MAX_NOTIFICATION_GROUPS,
-        MAXIMUM_MAX_NOTIFICATION_GROUPS,
         NodeScope,
         Dynamic
     )
@@ -331,7 +309,6 @@ internal object PluginSettings {
         MAX_NOTIFICATION_SENDERS_KEY,
         defaultSettings[MAX_NOTIFICATION_SENDERS_KEY]!!.toInt(),
         MINIMUM_MAX_NOTIFICATION_SENDERS,
-        MAXIMUM_MAX_NOTIFICATION_SENDERS,
         NodeScope,
         Dynamic
     )
@@ -340,7 +317,6 @@ internal object PluginSettings {
         MAX_ACTIVE_RESPONSES_KEY,
         defaultSettings[MAX_ACTIVE_RESPONSES_KEY]!!.toInt(),
         MINIMUM_MAX_ACTIVE_RESPONSES,
-        MAXIMUM_MAX_ACTIVE_RESPONSES,
         NodeScope,
         Dynamic
     )

--- a/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
+++ b/notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.opensearch.cluster.service.ClusterService
 import org.opensearch.common.settings.ClusterSettings
@@ -29,6 +30,10 @@ internal class PluginSettingsTests {
     private val alertingFilterByBackendRolesKey = "plugins.alerting.filter_by_backend_roles"
     private val filterByBackendRolesKey = "$generalKeyPrefix.filter_by_backend_roles"
     private val multiTenancyEnabledKey = "plugins.notifications.multi_tenancy_enabled"
+    private val maxNotificationConfigsKey = "plugins.notifications.max_notification_configs"
+    private val maxNotificationGroupsKey = "plugins.notifications.max_notification_groups"
+    private val maxNotificationSendersKey = "plugins.notifications.max_notification_senders"
+    private val maxActiveResponsesKey = "plugins.notifications.max_active_responses"
 
     private val defaultSettings = Settings.builder()
         .put(operationTimeoutKey, 60000L)
@@ -265,6 +270,83 @@ internal class PluginSettingsTests {
             .put(multiTenancyEnabledKey, true)
             .build()
         Assertions.assertEquals(true, PluginSettings.MULTI_TENANCY_ENABLED.get(settings))
+    }
+
+    @Test
+    fun `test resource limit settings fall back to their defaults`() {
+        Assertions.assertEquals(40, PluginSettings.MAX_NOTIFICATION_CONFIGS.get(Settings.EMPTY))
+        Assertions.assertEquals(10, PluginSettings.MAX_NOTIFICATION_GROUPS.get(Settings.EMPTY))
+        Assertions.assertEquals(5, PluginSettings.MAX_NOTIFICATION_SENDERS.get(Settings.EMPTY))
+        Assertions.assertEquals(10, PluginSettings.MAX_ACTIVE_RESPONSES.get(Settings.EMPTY))
+    }
+
+    @Test
+    fun `test resource limit settings have no upper bound`() {
+        val settings = Settings.builder()
+            .put(maxNotificationConfigsKey, 100000)
+            .put(maxNotificationGroupsKey, 100000)
+            .put(maxNotificationSendersKey, 100000)
+            .put(maxActiveResponsesKey, 100000)
+            .build()
+
+        Assertions.assertEquals(100000, PluginSettings.MAX_NOTIFICATION_CONFIGS.get(settings))
+        Assertions.assertEquals(100000, PluginSettings.MAX_NOTIFICATION_GROUPS.get(settings))
+        Assertions.assertEquals(100000, PluginSettings.MAX_NOTIFICATION_SENDERS.get(settings))
+        Assertions.assertEquals(100000, PluginSettings.MAX_ACTIVE_RESPONSES.get(settings))
+    }
+
+    @Test
+    fun `test resource limit settings accept Integer MAX_VALUE`() {
+        val settings = Settings.builder()
+            .put(maxNotificationConfigsKey, Int.MAX_VALUE)
+            .put(maxNotificationGroupsKey, Int.MAX_VALUE)
+            .put(maxNotificationSendersKey, Int.MAX_VALUE)
+            .put(maxActiveResponsesKey, Int.MAX_VALUE)
+            .build()
+
+        Assertions.assertEquals(Int.MAX_VALUE, PluginSettings.MAX_NOTIFICATION_CONFIGS.get(settings))
+        Assertions.assertEquals(Int.MAX_VALUE, PluginSettings.MAX_NOTIFICATION_GROUPS.get(settings))
+        Assertions.assertEquals(Int.MAX_VALUE, PluginSettings.MAX_NOTIFICATION_SENDERS.get(settings))
+        Assertions.assertEquals(Int.MAX_VALUE, PluginSettings.MAX_ACTIVE_RESPONSES.get(settings))
+    }
+
+    @Test
+    fun `test resource limit settings accept zero`() {
+        val settings = Settings.builder()
+            .put(maxNotificationConfigsKey, 0)
+            .put(maxNotificationGroupsKey, 0)
+            .put(maxNotificationSendersKey, 0)
+            .put(maxActiveResponsesKey, 0)
+            .build()
+
+        Assertions.assertEquals(0, PluginSettings.MAX_NOTIFICATION_CONFIGS.get(settings))
+        Assertions.assertEquals(0, PluginSettings.MAX_NOTIFICATION_GROUPS.get(settings))
+        Assertions.assertEquals(0, PluginSettings.MAX_NOTIFICATION_SENDERS.get(settings))
+        Assertions.assertEquals(0, PluginSettings.MAX_ACTIVE_RESPONSES.get(settings))
+    }
+
+    @Test
+    fun `test resource limit settings reject negative values`() {
+        assertThrows<IllegalArgumentException> {
+            PluginSettings.MAX_NOTIFICATION_CONFIGS.get(
+                Settings.builder().put(maxNotificationConfigsKey, -1).build()
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            PluginSettings.MAX_NOTIFICATION_GROUPS.get(
+                Settings.builder().put(maxNotificationGroupsKey, -1).build()
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            PluginSettings.MAX_NOTIFICATION_SENDERS.get(
+                Settings.builder().put(maxNotificationSendersKey, -1).build()
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            PluginSettings.MAX_ACTIVE_RESPONSES.get(
+                Settings.builder().put(maxActiveResponsesKey, -1).build()
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
## Description

The four notification resource limits (`max_notification_configs`, `max_notification_groups`, `max_notification_senders`, `max_active_responses`) were declared with hard-coded upper bounds of `40`, `10`, `5` and `10`, and each bound doubled as its setting's default.
CTI team has hit this ceiling. This PR removes the ceilings, so the settings are fully customizable, leaving the defaults (`40`, `10`, `5`, `10`) and the minimums (`0`) untouched.

Closes https://github.com/wazuh/wazuh-indexer-plugins/issues/1420 *(notifications side)*


## Proposed Changes

- Deleted the private `MAXIMUM_MAX_NOTIFICATION_CONFIGS`, `MAXIMUM_MAX_NOTIFICATION_GROUPS`, `MAXIMUM_MAX_NOTIFICATION_SENDERS` and `MAXIMUM_MAX_ACTIVE_RESPONSES` constants, and dropped the `max` argument from the four corresponding `Setting.intSetting` declarations.
- The `DEFAULT_MAX_*_VALUE` constants are now literals (`40`, `10`, `5`, `10`) instead of aliases of the deleted maximums, so the defaults no longer move with ceilings that no longer exist.
- The `MINIMUM_MAX_*` constants (`0`) are kept and still passed to `Setting.intSetting`, so negative values remain rejected.


### Results and Evidence

**Unit tests**: `PluginSettingsTests`, 16 tests, 0 failures, 0 errors (5 new, 11 pre-existing):

``` console
jorge@jorge-wazuh:~/wazuh/wazuh-indexer-notifications/notifications$ ./gradlew :notifications:test --tests "*settings.PluginSettingsTests*"
...
BUILD SUCCESSFUL in 11s
13 actionable tasks: 2 executed, 3 from cache, 8 up-to-date
```


**Testing in a real deploy**:
Before deploying the change, the ceilings were enforced

After deploying:

| Check | Result |
| --- | --- |
| `PUT _cluster/settings` with `100000`, all four settings | 200, values read back correctly |
| `PUT _cluster/settings` with `-1`, all four settings | 400 `Failed to parse value [-1] for setting [<key>] must be >= 0` |
| Effective defaults with both scopes nulled | `40` / `10` / `5` / `10` (unchanged) |
| Raise `max_notification_senders` to `8`, create 8 `smtp_account` configs | all 8 created (old ceiling was 5) |
| Raise `max_notification_groups` to `12`, create 12 `email_group` configs | all 12 created (old ceiling was 10) |
| Raise `max_active_responses` to `12`, create 12 `active_response` configs | all 12 created (old ceiling was 10) |
| Create the N+1 config in each of the three cases | 400 `This request would exceed the maximum allowed notification senders [8]` (and the equivalent for groups / active responses) — the limits still bite, at the configured values |

### Artifacts Affected

- `wazuh-indexer-notifications` plugin

### Configuration Changes

| Setting | Before | After |
| --- | --- | --- |
| `plugins.notifications.max_notification_configs` | Integer, default `40`, range `0`–`40`, dynamic | Integer, default `40`, minimum `0`, **no upper bound**, dynamic |
| `plugins.notifications.max_notification_groups` | Integer, default `10`, range `0`–`10`, dynamic | Integer, default `10`, minimum `0`, **no upper bound**, dynamic |
| `plugins.notifications.max_notification_senders` | Integer, default `5`, range `0`–`5`, dynamic | Integer, default `5`, minimum `0`, **no upper bound**, dynamic |
| `plugins.notifications.max_active_responses` | Integer, default `10`, range `0`–`10`, dynamic | Integer, default `10`, minimum `0`, **no upper bound**, dynamic |

- No new settings, no renamed settings, no removed settings.
- Default values unchanged, minimums unchanged (`0`), scope and dynamism unchanged.

### Documentation Updates

The user-facing settings reference for this plugin lives in the `wazuh-indexer-plugins` repository, so the doc change ships in the companion PR there:

- `docs/ref/modules/notifications/configuration.md`

### Tests Introduced

Five new cases in `notifications/notifications/src/test/kotlin/org/opensearch/notifications/settings/PluginSettingsTests.kt`, each covering all four settings:

| Test | Scope |
| --- | --- |
| `test resource limit settings fall back to their defaults` | Guards the four defaults against accidental drift now that they are literals rather than aliases of the deleted maximums. |
| `test resource limit settings have no upper bound` | The regression test for this change: asserts `100000` parses for all four settings. Every one would have thrown before. |
| `test resource limit settings accept Integer MAX_VALUE` | Upper extreme — confirms nothing else clamps the value on the way through. |
| `test resource limit settings accept zero` | Confirms `0` is still valid (creation blocked), i.e. the floors were not moved while removing the ceilings. |
| `test resource limit settings reject negative values` | Confirms `-1` still throws `IllegalArgumentException` for each of the four settings. |

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
- [x] Tests cover the new functionality
- [x] Configuration changes documented
- [x] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
- [ ] ...